### PR TITLE
add a github actions task to check wasm builds work

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,3 +62,19 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  wasm:
+    name: WasmBuild
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup target add wasm32-unknown-unknown
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target wasm32-unknown-unknown


### PR DESCRIPTION

I decided to see if our current codebase supports building to Wasm and it does! It is important we keep it this way and avoid adding dependencies or patterns that Wasm doesn't support. Future PRs will fail to pass CI if they do not support building to Wasm.

**Summary of changes**
Changes introduced in this pull request:
- Adds a github action task that installs the Wasm target and runs cargo check against it

**Other information and links**
<!-- Add any other context about the pull request here. -->

Based off suggestion here: https://rustwasm.github.io/docs/book/reference/add-wasm-support-to-crate.html#maintaining-ongoing-support-for-webassembly

<!-- Thank you 🔥 -->