### PR TITLE
Run CI jobs on working branches only

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, types-working-bee-base]
+  pull_request:
+    branches: [main, types-working-bee-base]
 
 name: Continuous integration
 

--- a/.github/workflows/check-licence.yml
+++ b/.github/workflows/check-licence.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, types-working-bee-base]
+  pull_request:
+    branches: [main, types-working-bee-base]
 
 name: Check Licence
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Only run CI jobs on push / pr to working branches to avoid spamming it.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->