### PR TITLE
bump editions in Cargo.toml files to 2021

### DIFF
--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mina-rs-base"
 version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.126", features = ["derive"] }

--- a/bin-prot/Cargo.toml
+++ b/bin-prot/Cargo.toml
@@ -3,7 +3,7 @@ name = "bin-prot"
 version = "0.1.0"
 license = "Apache-2.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 byteorder = "1.4.3"

--- a/bin_prot_checker/Cargo.toml
+++ b/bin_prot_checker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bin_prot_checker"
 version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.126", features = ["derive"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mina-consensus"
 version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 hex = "0.4.3"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mina-crypto"
 version = "0.1.0"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bs58 = { version = "0.4.0", features = ["check"] }

--- a/test-serialization/Cargo.toml
+++ b/test-serialization/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-serialization"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dev-dependencies]
 serde = { version = "1.0.126", features = ["derive"] }

--- a/wire-type-derive/Cargo.toml
+++ b/wire-type-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wire-type-derive"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/wire-type/Cargo.toml
+++ b/wire-type/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wire-type"
 authors = ["ChainSafe Systems <info@chainsafe.io>"]
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.126" }


### PR DESCRIPTION
Well that was painless

**Summary of changes**
Changes introduced in this pull request:
- Updates edition in the Cargo.toml for all crates

<!-- Thank you 🔥 -->