### PR TITLE
Put binprot loosely-typed deserialization behind optional feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,6 +1638,7 @@ dependencies = [
  "mina-crypto",
  "mina-rs-base",
  "pretty_assertions",
+ "rand",
  "serde",
  "test-fixtures",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,6 @@ name = "bin-prot"
 version = "0.1.0"
 dependencies = [
  "byteorder",
- "duplicate",
  "num",
  "serde",
  "serde_json",
@@ -254,7 +253,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58bdf5134c5beae6fc382002c4d88950bad1feea20f8f7165494b6b43b049de"
 dependencies = [
- "digest 0.10.0",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -480,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567569e659735adb39ff2d4c20600f7cd78be5471f8c58ab162bce3c03fdbc5f"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
 dependencies = [
  "generic-array",
 ]
@@ -505,7 +504,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -617,24 +616,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8549e6bfdecd113b7e221fe60b433087f6957387a20f8118ebca9b12af19143d"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
  "block-buffer 0.10.0",
  "crypto-common",
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "duplicate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cdaf23abc9bcc47fda1ae3af68425a22b4dfbd745f9077be0eaad5320f75f52"
-dependencies = [
- "heck",
- "proc-macro-error",
 ]
 
 [[package]]
@@ -705,18 +694,18 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.20"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a30908dbce072eca83216eab939d2290080e00ca71611b96a09e5cdce5f3fa"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -758,6 +747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,9 +769,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.110"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libm"
@@ -1047,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"
@@ -1218,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
@@ -1379,9 +1374,9 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -1460,11 +1455,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]

--- a/protocol/bin-prot/Cargo.toml
+++ b/protocol/bin-prot/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [features]
 default = []
 
-layout = [
+loose_deserialization = [
   "serde_json",
 ]
 

--- a/protocol/bin-prot/Cargo.toml
+++ b/protocol/bin-prot/Cargo.toml
@@ -6,13 +6,19 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
+[features]
+default = []
+
+layout = [
+  "serde_json",
+]
+
 [dependencies]
-byteorder = "1.4.3"
-duplicate = "0.3.0"
-num = "0.4.0"
+byteorder = "1.4"
+num = "0.4"
 serde = "1"
-serde_json = "1"
-thiserror = "1.0.24"
+serde_json = {version = "1", optional = true}
+thiserror = "1"
 
 [dev-dependencies]
 serde = {version = "1", features = ["derive"]}

--- a/protocol/bin-prot/README.md
+++ b/protocol/bin-prot/README.md
@@ -27,7 +27,7 @@ fn main() {
 
   // Read back into a typed value
   let de_val: Vec<i64> = from_reader(output.as_slice()).unwrap();
-  
+
   assert!(val == de_val)
 }
 
@@ -35,8 +35,15 @@ fn main() {
 
 ### Loosely Typed
 
-Despite bin_prot being a non-self-describing format it is possible to deserialize into a loosely typed value if a layout descriptor file is provided. The layout files are typically written in JSON and describe the nested data structure that 
+Despite bin_prot being a non-self-describing format it is possible to deserialize into a loosely typed value if a layout descriptor file is provided. The layout files are typically written in JSON and describe the nested data structure that
 is to be deserialized. For the specification of the BinProtRule type see src/value/layout/mod.rs.
+
+Note that, Loosely-typed deserialization is behind feature `loose_deserialization` which is disabled by default. Use below config snippet to turn it on.
+
+```toml
+# in Cargo.toml
+bin-prot = {version="$version", features = ["loose_deserialization"]}
+```
 
 These are created using the `Deserializer::from_reader_with_layout` constructor.
 

--- a/protocol/bin-prot/src/de.rs
+++ b/protocol/bin-prot/src/de.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::{Error, Result};
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 use crate::value::layout::*;
 use crate::ReadBinProtExt;
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -13,7 +13,7 @@ use std::io::{BufReader, Read};
 // the modes of operation for the deserializer
 pub struct StronglyTyped;
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 pub struct LooselyTyped {
     pub layout_iter: BinProtRuleIterator,
 }
@@ -32,7 +32,7 @@ impl<R: Read> Deserializer<R, StronglyTyped> {
     }
 }
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 impl<R: Read> Deserializer<R, StronglyTyped> {
     pub fn with_layout(self, layout: &BinProtRule) -> Deserializer<R, LooselyTyped> {
         Deserializer {
@@ -52,7 +52,7 @@ pub fn from_reader<'de, R: Read, T: Deserialize<'de>>(rdr: R) -> Result<T> {
 
 // In the loosely typed case we want to use deserialize_any for every field
 // This includes the hybrid strong/loose case
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R, LooselyTyped> {
     type Error = Error;
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
@@ -366,7 +366,7 @@ macro_rules! impl_enum_access {
 
 impl_enum_access!(StronglyTyped);
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 impl_enum_access!(LooselyTyped);
 
 // `VariantAccess` is provided to the `Visitor` to give it the ability to see
@@ -410,7 +410,7 @@ macro_rules! impl_variant_access {
 
 impl_variant_access!(StronglyTyped);
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 impl_variant_access!(LooselyTyped);
 
 pub(crate) struct MapAccess<'a, R: Read + 'a, Mode> {
@@ -458,7 +458,7 @@ macro_rules! impl_map_access {
 
 impl_map_access!(StronglyTyped);
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 impl_map_access!(LooselyTyped);
 
 pub(crate) struct SeqAccess<'a, R: Read + 'a, Mode> {
@@ -518,5 +518,5 @@ macro_rules! impl_seq_access {
 
 impl_seq_access!(StronglyTyped);
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 impl_seq_access!(LooselyTyped);

--- a/protocol/bin-prot/src/de.rs
+++ b/protocol/bin-prot/src/de.rs
@@ -1,18 +1,19 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::{BufReader, Read};
-
 use crate::error::{Error, Result};
-use crate::value::layout::{BinProtRule, BinProtRuleIterator};
+#[cfg(feature = "layout")]
+use crate::value::layout::*;
 use crate::ReadBinProtExt;
 use byteorder::{LittleEndian, ReadBytesExt};
-use duplicate::duplicate;
 use serde::de::{self, value::U8Deserializer, EnumAccess, IntoDeserializer, Visitor};
 use serde::Deserialize;
+use std::io::{BufReader, Read};
 
 // the modes of operation for the deserializer
 pub struct StronglyTyped;
+
+#[cfg(feature = "layout")]
 pub struct LooselyTyped {
     pub layout_iter: BinProtRuleIterator,
 }
@@ -31,6 +32,7 @@ impl<R: Read> Deserializer<R, StronglyTyped> {
     }
 }
 
+#[cfg(feature = "layout")]
 impl<R: Read> Deserializer<R, StronglyTyped> {
     pub fn with_layout(self, layout: &BinProtRule) -> Deserializer<R, LooselyTyped> {
         Deserializer {
@@ -50,6 +52,7 @@ pub fn from_reader<'de, R: Read, T: Deserialize<'de>>(rdr: R) -> Result<T> {
 
 // In the loosely typed case we want to use deserialize_any for every field
 // This includes the hybrid strong/loose case
+#[cfg(feature = "layout")]
 impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R, LooselyTyped> {
     type Error = Error;
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
@@ -343,52 +346,72 @@ impl<'a, 'de, R: Read, Mode> Enum<'a, R, Mode> {
 
 // `EnumAccess` is provided to the `Visitor` to give it the ability to determine
 // which variant of the enum is supposed to be deserialized.
-#[duplicate(Mode; [StronglyTyped]; [LooselyTyped])]
-impl<'de, 'a, R: Read> EnumAccess<'de> for Enum<'a, R, Mode> {
-    type Error = Error;
-    type Variant = Self;
+macro_rules! impl_enum_access {
+    ($ty: ty) => {
+        impl<'de, 'a, R: Read> EnumAccess<'de> for Enum<'a, R, $ty> {
+            type Error = Error;
+            type Variant = Self;
 
-    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
-    where
-        V: de::DeserializeSeed<'de>,
-    {
-        let de: U8Deserializer<Self::Error> = (self.index as u8).into_deserializer();
-        let v = seed.deserialize(de)?;
-        Ok((v, self))
-    }
+            fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+            where
+                V: de::DeserializeSeed<'de>,
+            {
+                let de: U8Deserializer<Self::Error> = (self.index as u8).into_deserializer();
+                let v = seed.deserialize(de)?;
+                Ok((v, self))
+            }
+        }
+    };
 }
+
+impl_enum_access!(StronglyTyped);
+
+#[cfg(feature = "layout")]
+impl_enum_access!(LooselyTyped);
 
 // `VariantAccess` is provided to the `Visitor` to give it the ability to see
 // the content of the single variant that it decided to deserialize.
-#[duplicate(Mode; [StronglyTyped]; [LooselyTyped])]
-impl<'de, 'a, R: Read> de::VariantAccess<'de> for Enum<'a, R, Mode> {
-    type Error = Error;
+macro_rules! impl_variant_access {
+    ($ty: ty) => {
+        impl<'de, 'a, R: Read> de::VariantAccess<'de> for Enum<'a, R, $ty> {
+            type Error = Error;
 
-    fn unit_variant(self) -> Result<()> {
-        Ok(())
-    }
+            fn unit_variant(self) -> Result<()> {
+                Ok(())
+            }
 
-    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
-    where
-        T: de::DeserializeSeed<'de>,
-    {
-        seed.deserialize(self.de)
-    }
+            fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+            where
+                T: de::DeserializeSeed<'de>,
+            {
+                seed.deserialize(self.de)
+            }
 
-    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        de::Deserializer::deserialize_tuple(self.de, len, visitor)
-    }
+            fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value>
+            where
+                V: Visitor<'de>,
+            {
+                de::Deserializer::deserialize_tuple(self.de, len, visitor)
+            }
 
-    fn struct_variant<V>(self, fields: &'static [&'static str], visitor: V) -> Result<V::Value>
-    where
-        V: Visitor<'de>,
-    {
-        de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
-    }
+            fn struct_variant<V>(
+                self,
+                fields: &'static [&'static str],
+                visitor: V,
+            ) -> Result<V::Value>
+            where
+                V: Visitor<'de>,
+            {
+                de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
+            }
+        }
+    };
 }
+
+impl_variant_access!(StronglyTyped);
+
+#[cfg(feature = "layout")]
+impl_variant_access!(LooselyTyped);
 
 pub(crate) struct MapAccess<'a, R: Read + 'a, Mode> {
     de: &'a mut Deserializer<R, Mode>,
@@ -401,28 +424,42 @@ impl<'a, R: Read + 'a, Mode> MapAccess<'a, R, Mode> {
     }
 }
 
-#[duplicate(Mode; [StronglyTyped]; [LooselyTyped])]
-impl<'de: 'a, 'a, R: Read> de::MapAccess<'de> for MapAccess<'a, R, Mode> {
-    type Error = Error;
+macro_rules! impl_map_access {
+    ($ty: ty) => {
+        impl<'de: 'a, 'a, R: Read> de::MapAccess<'de> for MapAccess<'a, R, $ty> {
+            type Error = Error;
 
-    fn next_key_seed<T: de::DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>> {
-        if let Some(name) = self.field_names.pop() {
-            // create a new deserializer to read the name from memory
-            // as it isn't present in the serialized output
-            seed.deserialize(name.into_deserializer()).map(Some)
-        } else {
-            Ok(None)
+            fn next_key_seed<T: de::DeserializeSeed<'de>>(
+                &mut self,
+                seed: T,
+            ) -> Result<Option<T::Value>> {
+                if let Some(name) = self.field_names.pop() {
+                    // create a new deserializer to read the name from memory
+                    // as it isn't present in the serialized output
+                    seed.deserialize(name.into_deserializer()).map(Some)
+                } else {
+                    Ok(None)
+                }
+            }
+
+            fn next_value_seed<T: de::DeserializeSeed<'de>>(
+                &mut self,
+                seed: T,
+            ) -> Result<T::Value> {
+                seed.deserialize(&mut *self.de)
+            }
+
+            fn size_hint(&self) -> Option<usize> {
+                Some(self.field_names.len())
+            }
         }
-    }
-
-    fn next_value_seed<T: de::DeserializeSeed<'de>>(&mut self, seed: T) -> Result<T::Value> {
-        seed.deserialize(&mut *self.de)
-    }
-
-    fn size_hint(&self) -> Option<usize> {
-        Some(self.field_names.len())
-    }
+    };
 }
+
+impl_map_access!(StronglyTyped);
+
+#[cfg(feature = "layout")]
+impl_map_access!(LooselyTyped);
 
 pub(crate) struct SeqAccess<'a, R: Read + 'a, Mode> {
     de: &'a mut Deserializer<R, Mode>,
@@ -451,27 +488,35 @@ impl<'a, R: Read + 'a, Mode> SeqAccess<'a, R, Mode> {
     }
 }
 
-#[duplicate(Mode; [StronglyTyped]; [LooselyTyped])]
-impl<'de: 'a, 'a, R: Read> de::SeqAccess<'de> for SeqAccess<'a, R, Mode> {
-    type Error = Error;
+macro_rules! impl_seq_access {
+    ($ty: ty) => {
+        impl<'de: 'a, 'a, R: Read> de::SeqAccess<'de> for SeqAccess<'a, R, $ty> {
+            type Error = Error;
 
-    fn next_element_seed<T: de::DeserializeSeed<'de>>(
-        &mut self,
-        seed: T,
-    ) -> Result<Option<T::Value>> {
-        if self.len > 0 {
-            self.len -= 1;
-            seed.deserialize(&mut *self.de).map(Some)
-        } else {
-            Ok(None)
-        }
-    }
+            fn next_element_seed<T: de::DeserializeSeed<'de>>(
+                &mut self,
+                seed: T,
+            ) -> Result<Option<T::Value>> {
+                if self.len > 0 {
+                    self.len -= 1;
+                    seed.deserialize(&mut *self.de).map(Some)
+                } else {
+                    Ok(None)
+                }
+            }
 
-    fn size_hint(&self) -> Option<usize> {
-        if self.is_list {
-            Some(self.total_len)
-        } else {
-            None
+            fn size_hint(&self) -> Option<usize> {
+                if self.is_list {
+                    Some(self.total_len)
+                } else {
+                    None
+                }
+            }
         }
-    }
+    };
 }
+
+impl_seq_access!(StronglyTyped);
+
+#[cfg(feature = "layout")]
+impl_seq_access!(LooselyTyped);

--- a/protocol/bin-prot/src/lib.rs
+++ b/protocol/bin-prot/src/lib.rs
@@ -12,7 +12,7 @@ mod consts;
 mod de;
 pub mod error;
 pub mod integers;
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 mod loose_deserializer;
 mod read_ext;
 mod ser;
@@ -23,7 +23,7 @@ pub use array::OcamlArray;
 pub use de::{from_reader, Deserializer};
 pub use read_ext::ReadBinProtExt;
 pub use ser::{to_writer, Serializer};
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 pub use value::layout::{BinProtRule, Layout};
 pub use value::Value;
 pub use write_ext::WriteBinProtExt;

--- a/protocol/bin-prot/src/lib.rs
+++ b/protocol/bin-prot/src/lib.rs
@@ -12,6 +12,7 @@ mod consts;
 mod de;
 pub mod error;
 pub mod integers;
+#[cfg(feature = "layout")]
 mod loose_deserializer;
 mod read_ext;
 mod ser;
@@ -22,6 +23,7 @@ pub use array::OcamlArray;
 pub use de::{from_reader, Deserializer};
 pub use read_ext::ReadBinProtExt;
 pub use ser::{to_writer, Serializer};
+#[cfg(feature = "layout")]
 pub use value::layout::{BinProtRule, Layout};
 pub use value::Value;
 pub use write_ext::WriteBinProtExt;

--- a/protocol/bin-prot/src/value/mod.rs
+++ b/protocol/bin-prot/src/value/mod.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 mod enum_data;
 mod index;
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 pub mod layout;
 pub mod ser;
 mod visitor;

--- a/protocol/bin-prot/src/value/mod.rs
+++ b/protocol/bin-prot/src/value/mod.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 
 mod enum_data;
 mod index;
+#[cfg(feature = "layout")]
 pub mod layout;
 pub mod ser;
 mod visitor;

--- a/protocol/bin-prot/src/value/visitor.rs
+++ b/protocol/bin-prot/src/value/visitor.rs
@@ -1,11 +1,13 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "layout")]
 use crate::loose_deserializer::EnumData;
 use crate::value::Value;
 use serde::de::MapAccess;
 use serde::de::SeqAccess;
 use serde::de::Visitor;
+#[cfg(feature = "layout")]
 use serde::de::{EnumAccess, VariantAccess};
 use serde::Deserialize;
 
@@ -104,6 +106,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Record(values))
     }
 
+    #[cfg(feature = "layout")]
     fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
     where
         A: EnumAccess<'de>,

--- a/protocol/bin-prot/src/value/visitor.rs
+++ b/protocol/bin-prot/src/value/visitor.rs
@@ -1,13 +1,13 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 use crate::loose_deserializer::EnumData;
 use crate::value::Value;
 use serde::de::MapAccess;
 use serde::de::SeqAccess;
 use serde::de::Visitor;
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 use serde::de::{EnumAccess, VariantAccess};
 use serde::Deserialize;
 
@@ -106,7 +106,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
         Ok(Value::Record(values))
     }
 
-    #[cfg(feature = "layout")]
+    #[cfg(feature = "loose_deserialization")]
     fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
     where
         A: EnumAccess<'de>,

--- a/protocol/bin-prot/tests/layouts.rs
+++ b/protocol/bin-prot/tests/layouts.rs
@@ -1,13 +1,15 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-use bin_prot::value::layout::BinProtRule;
-use bin_prot::value::Value;
-use bin_prot::Deserializer;
-use serde::{Deserialize, Serialize};
-use std::io::Cursor;
+#[cfg(feature = "layout")]
+mod tests {
+    use bin_prot::value::layout::BinProtRule;
+    use bin_prot::value::Value;
+    use bin_prot::Deserializer;
+    use serde::{Deserialize, Serialize};
+    use std::io::Cursor;
 
-const SIMPLE_RULE: &str = r#"
+    const SIMPLE_RULE: &str = r#"
 [
   "Option",
   [
@@ -20,25 +22,25 @@ const SIMPLE_RULE: &str = r#"
 ]
 "#;
 
-#[test]
-fn test_simple_rule() {
-    let rule: BinProtRule = serde_json::from_str(SIMPLE_RULE).unwrap();
-    let example = vec![0x01, 0x00, 0x00]; // Some((0, false))
+    #[test]
+    fn test_simple_rule() {
+        let rule: BinProtRule = serde_json::from_str(SIMPLE_RULE).unwrap();
+        let example = vec![0x01, 0x00, 0x00]; // Some((0, false))
 
-    let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
 
-    assert_eq!(
-        result,
-        Value::Option(Some(Box::new(Value::Tuple(vec![
-            Value::Int(0),
-            Value::Bool(false)
-        ]))))
-    );
-    test_reserialize(&result, &example);
-}
+        assert_eq!(
+            result,
+            Value::Option(Some(Box::new(Value::Tuple(vec![
+                Value::Int(0),
+                Value::Bool(false)
+            ]))))
+        );
+        test_reserialize(&result, &example);
+    }
 
-const RECORD_RULE: &str = r#"
+    const RECORD_RULE: &str = r#"
 [
   "Record",
   [
@@ -49,59 +51,59 @@ const RECORD_RULE: &str = r#"
 ]
 "#;
 
-#[test]
-fn test_record_rule() {
-    let rule: BinProtRule = serde_json::from_str(RECORD_RULE).unwrap();
-    let example = vec![0x05, 0x00, 0x01];
+    #[test]
+    fn test_record_rule() {
+        let rule: BinProtRule = serde_json::from_str(RECORD_RULE).unwrap();
+        let example = vec![0x05, 0x00, 0x01];
 
-    let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
 
-    assert_eq!(
-        result,
-        Value::Record(vec![
-            ("first".to_string(), Value::Int(5)),
-            (
-                "second".to_string(),
-                Value::Record(vec![("inner".to_string(), Value::Bool(false))])
-            ),
-            ("third".to_string(), Value::Bool(true)),
-        ])
-    );
+        assert_eq!(
+            result,
+            Value::Record(vec![
+                ("first".to_string(), Value::Int(5)),
+                (
+                    "second".to_string(),
+                    Value::Record(vec![("inner".to_string(), Value::Bool(false))])
+                ),
+                ("third".to_string(), Value::Bool(true)),
+            ])
+        );
 
-    // also test using the indexing
-    assert_eq!(result["second"]["inner"], Value::Bool(false));
-    test_reserialize(&result, &example);
-}
-
-#[test]
-fn test_record_rule_partial() {
-    let rule: BinProtRule = serde_json::from_str(RECORD_RULE).unwrap();
-    let example = vec![0x05, 0x00, 0x01];
-
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
-    struct PartialType {
-        first: u8,
-        second: Value,
-        third: bool,
+        // also test using the indexing
+        assert_eq!(result["second"]["inner"], Value::Bool(false));
+        test_reserialize(&result, &example);
     }
 
-    let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
-    let result: PartialType = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+    #[test]
+    fn test_record_rule_partial() {
+        let rule: BinProtRule = serde_json::from_str(RECORD_RULE).unwrap();
+        let example = vec![0x05, 0x00, 0x01];
 
-    assert_eq!(
-        result,
-        PartialType {
-            first: 5,
-            second: Value::Record(vec![("inner".to_string(), Value::Bool(false))]),
-            third: true
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct PartialType {
+            first: u8,
+            second: Value,
+            third: bool,
         }
-    );
 
-    test_reserialize(&result, &example);
-}
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: PartialType = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
 
-const SUM_RULE: &str = r#"
+        assert_eq!(
+            result,
+            PartialType {
+                first: 5,
+                second: Value::Record(vec![("inner".to_string(), Value::Bool(false))]),
+                third: true
+            }
+        );
+
+        test_reserialize(&result, &example);
+    }
+
+    const SUM_RULE: &str = r#"
 [
   "Sum",
   [
@@ -119,25 +121,25 @@ const SUM_RULE: &str = r#"
 ]
 "#;
 
-#[test]
-fn test_sum_rule() {
-    let rule: BinProtRule = serde_json::from_str(SUM_RULE).unwrap();
-    let example = vec![0x01, 0x00]; // Two((false))
+    #[test]
+    fn test_sum_rule() {
+        let rule: BinProtRule = serde_json::from_str(SUM_RULE).unwrap();
+        let example = vec![0x01, 0x00]; // Two((false))
 
-    let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
-    assert_eq!(
-        result,
-        Value::Sum {
-            name: "two".to_string(),
-            index: 1,
-            value: Box::new(Value::Tuple(vec![Value::Bool(false)]))
-        }
-    );
-    test_reserialize(&result, &example);
-}
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        assert_eq!(
+            result,
+            Value::Sum {
+                name: "two".to_string(),
+                index: 1,
+                value: Box::new(Value::Tuple(vec![Value::Bool(false)]))
+            }
+        );
+        test_reserialize(&result, &example);
+    }
 
-const NESTED_SUM_RULE: &str = r#"
+    const NESTED_SUM_RULE: &str = r#"
 [
   "Sum",
   [
@@ -156,57 +158,59 @@ const NESTED_SUM_RULE: &str = r#"
 ]
 "#;
 
-#[test]
-fn test_nested_sum_rule() {
-    let rule: BinProtRule = serde_json::from_str(NESTED_SUM_RULE).unwrap();
-    let example = vec![0x00, 0x05]; // One({ first: 5 })
+    #[test]
+    fn test_nested_sum_rule() {
+        let rule: BinProtRule = serde_json::from_str(NESTED_SUM_RULE).unwrap();
+        let example = vec![0x00, 0x05]; // One({ first: 5 })
 
-    let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
-    assert_eq!(
-        result,
-        Value::Sum {
-            name: "one".to_string(),
-            index: 0,
-            value: Box::new(Value::Tuple(vec![Value::Record(vec![(
-                "first".to_string(),
-                Value::Int(5)
-            )])]))
-        }
-    );
-    test_reserialize(&result, &example);
-}
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        assert_eq!(
+            result,
+            Value::Sum {
+                name: "one".to_string(),
+                index: 0,
+                value: Box::new(Value::Tuple(vec![Value::Record(vec![(
+                    "first".to_string(),
+                    Value::Int(5)
+                )])]))
+            }
+        );
+        test_reserialize(&result, &example);
+    }
 
-const OPTION_RULE: &str = r#"
+    const OPTION_RULE: &str = r#"
 [
   "Option",
   ["Int"]
 ]
 "#;
 
-#[test]
-fn test_option_rule() {
-    let rule: BinProtRule = serde_json::from_str(OPTION_RULE).unwrap();
+    #[test]
+    fn test_option_rule() {
+        let rule: BinProtRule = serde_json::from_str(OPTION_RULE).unwrap();
 
-    let example_none = vec![0x00]; // None
+        let example_none = vec![0x00]; // None
 
-    let mut de = Deserializer::from_reader(Cursor::new(example_none.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
-    println!("{:?}", result);
-    assert_eq!(result, Value::Option(None));
+        let mut de =
+            Deserializer::from_reader(Cursor::new(example_none.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        println!("{:?}", result);
+        assert_eq!(result, Value::Option(None));
 
-    test_reserialize(&result, &example_none);
+        test_reserialize(&result, &example_none);
 
-    let example_some = vec![0x01, 0x07]; // Some(7)
+        let example_some = vec![0x01, 0x07]; // Some(7)
 
-    let mut de = Deserializer::from_reader(Cursor::new(example_some.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        let mut de =
+            Deserializer::from_reader(Cursor::new(example_some.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
 
-    assert_eq!(result, Value::Option(Some(Box::new(Value::Int(0x07)))));
-    test_reserialize(&result, &example_some);
-}
+        assert_eq!(result, Value::Option(Some(Box::new(Value::Int(0x07)))));
+        test_reserialize(&result, &example_some);
+    }
 
-const MULTIPLE_CTOR_ARG_SUM_RULE: &str = r#"
+    const MULTIPLE_CTOR_ARG_SUM_RULE: &str = r#"
 [
   "Sum",
   [
@@ -232,52 +236,53 @@ const MULTIPLE_CTOR_ARG_SUM_RULE: &str = r#"
 ]
 "#;
 
-#[test]
-fn test_multiple_ctor_arg_sum_rule() {
-    let rule: BinProtRule = serde_json::from_str(MULTIPLE_CTOR_ARG_SUM_RULE).unwrap();
-    let example = vec![0x00, 0x05, 0x06]; // One({ first: 5 }, { second: 6})
+    #[test]
+    fn test_multiple_ctor_arg_sum_rule() {
+        let rule: BinProtRule = serde_json::from_str(MULTIPLE_CTOR_ARG_SUM_RULE).unwrap();
+        let example = vec![0x00, 0x05, 0x06]; // One({ first: 5 }, { second: 6})
 
-    let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
-    assert_eq!(
-        result,
-        Value::Sum {
-            name: "one".to_string(),
-            index: 0,
-            value: Box::new(Value::Tuple(vec![
-                Value::Record(vec![("first".to_string(), Value::Int(5))]),
-                Value::Record(vec![("second".to_string(), Value::Int(6))])
-            ]))
-        }
-    );
-    test_reserialize(&result, &example);
-}
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        assert_eq!(
+            result,
+            Value::Sum {
+                name: "one".to_string(),
+                index: 0,
+                value: Box::new(Value::Tuple(vec![
+                    Value::Record(vec![("first".to_string(), Value::Int(5))]),
+                    Value::Record(vec![("second".to_string(), Value::Int(6))])
+                ]))
+            }
+        );
+        test_reserialize(&result, &example);
+    }
 
-#[test]
-fn test_extended_u32_rule() {
-    let rule: BinProtRule =
-        serde_json::from_str(include_str!("layouts/extended_uint32_rule.json")).unwrap();
-    let example = vec![0x01, 0x01, 0xff, 0xff];
-    let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
-    let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
-    test_reserialize(&result, &example);
-    let mut output = vec![];
-    let value = &result["t"]["t"];
-    bin_prot::to_writer(&mut output, value).expect("Failed writing bin-prot encoded data");
-    assert_eq!(output, [0xff, 0xff]);
-    assert_eq!(
-        value,
-        &Value::Int(-1),
-        "Integer expected, but found {:#?}",
-        value
-    );
-}
+    #[test]
+    fn test_extended_u32_rule() {
+        let rule: BinProtRule =
+            serde_json::from_str(include_str!("layouts/extended_uint32_rule.json")).unwrap();
+        let example = vec![0x01, 0x01, 0xff, 0xff];
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        test_reserialize(&result, &example);
+        let mut output = vec![];
+        let value = &result["t"]["t"];
+        bin_prot::to_writer(&mut output, value).expect("Failed writing bin-prot encoded data");
+        assert_eq!(output, [0xff, 0xff]);
+        assert_eq!(
+            value,
+            &Value::Int(-1),
+            "Integer expected, but found {:#?}",
+            value
+        );
+    }
 
-pub fn test_reserialize<T>(val: &T, bytes: &[u8])
-where
-    T: Serialize,
-{
-    let mut output = vec![];
-    bin_prot::to_writer(&mut output, val).expect("Failed writing bin-prot encoded data");
-    assert_eq!(bytes, output)
+    pub fn test_reserialize<T>(val: &T, bytes: &[u8])
+    where
+        T: Serialize,
+    {
+        let mut output = vec![];
+        bin_prot::to_writer(&mut output, val).expect("Failed writing bin-prot encoded data");
+        assert_eq!(bytes, output)
+    }
 }

--- a/protocol/bin-prot/tests/layouts.rs
+++ b/protocol/bin-prot/tests/layouts.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "layout")]
+#[cfg(feature = "loose_deserialization")]
 mod tests {
     use bin_prot::value::layout::BinProtRule;
     use bin_prot::value::Value;

--- a/protocol/test-fixtures/Cargo.toml
+++ b/protocol/test-fixtures/Cargo.toml
@@ -8,7 +8,8 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-bin-prot = {path = "../bin-prot"}
+# layout support should only be used in tests
+bin-prot = {path = "../bin-prot", features = ["layout"]}
 mina-rs-base = {path = "../../base"}
 
 anyhow = "1"

--- a/protocol/test-fixtures/Cargo.toml
+++ b/protocol/test-fixtures/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 # layout support should only be used in tests
-bin-prot = {path = "../bin-prot", features = ["layout"]}
+bin-prot = {path = "../bin-prot", features = ["loose_deserialization"]}
 mina-rs-base = {path = "../../base"}
 
 anyhow = "1"

--- a/protocol/test-serialization/Cargo.toml
+++ b/protocol/test-serialization/Cargo.toml
@@ -24,6 +24,7 @@ base64 = "0.13"
 bs58 = {version = "0.4", features = ["check"]}
 criterion = {version = "0.3", features = ["html_reports"]}
 pretty_assertions = "1"
+rand = "0.8"
 serde = {version = "1", features = ["derive"]}
 time = {version = "0.3", features = ["macros"]}
 wasm-bindgen-test = "0.3"

--- a/protocol/test-serialization/src/fuzz.rs
+++ b/protocol/test-serialization/src/fuzz.rs
@@ -1,0 +1,61 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use crate::fuzz_test;
+    use bin_prot::Deserializer;
+    use mina_rs_base::types::*;
+    use rand::prelude::*;
+    use serde::Deserialize;
+    use wasm_bindgen_test::*;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_corrupted_deserialization() {
+        fuzz_test!(
+            ExternalTransition
+
+            ProtocolState
+            ProtocolStateBody
+            BlockchainState
+            ConsensusState
+            ProtocolConstants
+
+            ProtocolStateProof
+            ProofStatement
+            PrevEvals
+            Proof
+            ProofMessages
+            ProofOpenings
+
+            StagedLedgerDiff
+            StagedLedgerDiffTuple
+            StagedLedgerPreDiffTwo
+
+            DeltaTransitionChainProof
+
+            Option<ProtocolVersion>
+            ()
+        );
+    }
+
+    #[macro_export]
+    macro_rules! fuzz_test {
+        ($($ty: ty) *) => {
+            $(
+                let mut rng = rand::thread_rng();
+                for _i in 0..5 {
+                    let mut bytes = vec![0; rng.gen_range((1024 * 1024)..(50 * 1024 * 1024))];
+                    rng.try_fill_bytes(&mut bytes).unwrap();
+                    let et: anyhow::Result<$ty> = (|| {
+                        let mut de = Deserializer::from_reader(bytes.as_slice());
+                        let et: $ty = Deserialize::deserialize(&mut de)?;
+                        Ok(et)
+                    })();
+                    et.unwrap_err();
+                }
+            )*
+        };
+    }
+}

--- a/protocol/test-serialization/src/fuzz.rs
+++ b/protocol/test-serialization/src/fuzz.rs
@@ -40,11 +40,22 @@ mod tests {
         );
     }
 
+    #[test]
+    #[wasm_bindgen_test]
+    fn ensure_non_exhaustive_deserialization() {
+        let mut rng = StdRng::from_seed([0; 32]);
+        let mut bytes = vec![0; rng.gen_range((1024 * 1024)..(50 * 1024 * 1024))];
+
+        bytes[0] = 1;
+        let mut de = Deserializer::from_reader(bytes.as_slice());
+        let _et: ProtocolVersion = Deserialize::deserialize(&mut de).unwrap();
+    }
+
     #[macro_export]
     macro_rules! fuzz_test {
         ($($ty: ty) *) => {
             $(
-                let mut rng = rand::thread_rng();
+                let mut rng = StdRng::from_seed([0; 32]);
                 for _i in 0..5 {
                     let mut bytes = vec![0; rng.gen_range((1024 * 1024)..(50 * 1024 * 1024))];
                     rng.try_fill_bytes(&mut bytes).unwrap();

--- a/protocol/test-serialization/src/lib.rs
+++ b/protocol/test-serialization/src/lib.rs
@@ -4,28 +4,27 @@
 #[cfg(all(test, feature = "browser"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
+mod fuzz;
 #[allow(non_snake_case)]
 mod test_3NKaBJsN1SehD6iJwRwJSFmVzJg5DXSUQVgnMxtH4eer4aF5BrDK;
 
 #[cfg(test)]
 mod tests {
     use super::{block_path_test, block_path_test_batch};
-    use bin_prot::{from_reader, to_writer, Deserializer, Value};
+    use bin_prot::{from_reader, to_writer, Value};
     use mina_crypto::hash::*;
     use mina_crypto::signature::{
         FieldPoint, InnerCurveScalar, PublicKey, PublicKey2, PublicKey3, Signature,
     };
+    use mina_rs_base::protocol_state_proof::proof_messages::{
+        ProofMessageWithDegreeBound, ProofMessageWithoutDegreeBoundList,
+    };
     use mina_rs_base::types::*;
     use pretty_assertions::assert_eq;
-    use rand::prelude::*;
     use serde::{Deserialize, Serialize};
     use std::str::FromStr;
     use test_fixtures::*;
     use wasm_bindgen_test::*;
-
-    use mina_rs_base::protocol_state_proof::proof_messages::{
-        ProofMessageWithDegreeBound, ProofMessageWithoutDegreeBoundList,
-    };
 
     #[test]
     #[wasm_bindgen_test]
@@ -499,22 +498,6 @@ mod tests {
 
         // check roundtrip
         test_roundtrip(&block.value, block.bytes.as_slice());
-    }
-
-    #[test]
-    #[wasm_bindgen_test]
-    fn test_corrupted_deserialization() {
-        let mut rng = rand::thread_rng();
-        for _i in 0..100 {
-            let mut bytes = vec![0; rng.gen_range((1024 * 1024)..(100 * 1024 * 1024))];
-            rng.try_fill_bytes(&mut bytes).unwrap();
-            let et: anyhow::Result<ExternalTransition> = (|| {
-                let mut de = Deserializer::from_reader(bytes.as_slice());
-                let et: ExternalTransition = Deserialize::deserialize(&mut de)?;
-                Ok(et)
-            })();
-            et.unwrap_err();
-        }
     }
 
     #[test]

--- a/protocol/test-serialization/src/lib.rs
+++ b/protocol/test-serialization/src/lib.rs
@@ -10,13 +10,14 @@ mod test_3NKaBJsN1SehD6iJwRwJSFmVzJg5DXSUQVgnMxtH4eer4aF5BrDK;
 #[cfg(test)]
 mod tests {
     use super::{block_path_test, block_path_test_batch};
-    use bin_prot::{from_reader, to_writer, Value};
+    use bin_prot::{from_reader, to_writer, Deserializer, Value};
     use mina_crypto::hash::*;
     use mina_crypto::signature::{
         FieldPoint, InnerCurveScalar, PublicKey, PublicKey2, PublicKey3, Signature,
     };
     use mina_rs_base::types::*;
     use pretty_assertions::assert_eq;
+    use rand::prelude::*;
     use serde::{Deserialize, Serialize};
     use std::str::FromStr;
     use test_fixtures::*;
@@ -498,6 +499,22 @@ mod tests {
 
         // check roundtrip
         test_roundtrip(&block.value, block.bytes.as_slice());
+    }
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_corrupted_deserialization() {
+        let mut rng = rand::thread_rng();
+        for _i in 0..100 {
+            let mut bytes = vec![0; rng.gen_range((1024 * 1024)..(100 * 1024 * 1024))];
+            rng.try_fill_bytes(&mut bytes).unwrap();
+            let et: anyhow::Result<ExternalTransition> = (|| {
+                let mut de = Deserializer::from_reader(bytes.as_slice());
+                let et: ExternalTransition = Deserialize::deserialize(&mut de)?;
+                Ok(et)
+            })();
+            et.unwrap_err();
+        }
     }
 
     #[test]

--- a/protocol/test-serialization/src/test_3NKaBJsN1SehD6iJwRwJSFmVzJg5DXSUQVgnMxtH4eer4aF5BrDK.rs
+++ b/protocol/test-serialization/src/test_3NKaBJsN1SehD6iJwRwJSFmVzJg5DXSUQVgnMxtH4eer4aF5BrDK.rs
@@ -1,9 +1,6 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(all(test, feature = "browser"))]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
-
 #[cfg(test)]
 mod tests {
     use anyhow::bail;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- To address https://github.com/ChainSafe/mina-rs/pull/94#issuecomment-988041836
- Add feature `layout` to bin-prot crate
- Turn off `layout` feature for non-testing crates
- Test block deserialization (w/o layout) with random data to make sure it fails gracefully

@jspada plz review


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->