### PR TITLE
add polyvar deserialization support

### DIFF
--- a/apps/bin-prot-layout-reader/src/main.rs
+++ b/apps/bin-prot-layout-reader/src/main.rs
@@ -80,7 +80,10 @@ fn main() -> Result<()> {
         let mut reserialized_bytes = Vec::<u8>::new();
         bin_prot::to_writer(&mut reserialized_bytes, &result)
             .context("Failed to write result back to binary")?;
-        assert_eq!(bytes, reserialized_bytes, "Reserialized binary is not identical to the original!");
+        assert_eq!(
+            bytes, reserialized_bytes,
+            "Reserialized binary is not identical to the original!"
+        );
     }
 
     // pretty print the result (or write to a file)

--- a/apps/bin-prot-layout-reader/src/main.rs
+++ b/apps/bin-prot-layout-reader/src/main.rs
@@ -26,6 +26,10 @@ struct Opt {
     #[structopt(parse(from_os_str))]
     binary: PathBuf,
 
+    /// Test roundtrip
+    #[structopt(long, short)]
+    roundtrip: bool,
+
     /// Output file, stdout if not present
     #[structopt(long, short, parse(from_os_str))]
     output: Option<PathBuf>,
@@ -54,13 +58,12 @@ fn main() -> Result<()> {
         .with_context(|| format!("Could not open binary file to read: {:?}", opt.binary))?;
     let mut reader = BufReader::new(binary_file);
     let mut buffer = Vec::new();
-    reader.read_to_end(&mut buffer).unwrap();
+    reader.read_to_end(&mut buffer)?;
 
     // How to know which one to use? Try and decode hex first and if that fails
     // fallback to binary interpretation
     let bytes = if let Ok(hex_bytes) = hex::decode(&buffer) {
         info!("Identified HEX encoded string input");
-        println!("{:?}", hex_bytes);
         hex_bytes
     } else {
         info!("Interpreting binary as raw bytes");
@@ -71,6 +74,14 @@ fn main() -> Result<()> {
     let mut de = bin_prot::Deserializer::from_reader(&bytes[..]).with_layout(&layout.bin_prot_rule);
     let result: bin_prot::Value = Deserialize::deserialize(&mut de)
         .context("Failed to deserialize binary file with given layout")?;
+
+    if opt.roundtrip {
+        // check it can be serialized back to binary and the result is the same. Otherwise we have a problem.
+        let mut reserialized_bytes = Vec::<u8>::new();
+        bin_prot::to_writer(&mut reserialized_bytes, &result)
+            .context("Failed to write result back to binary")?;
+        assert_eq!(bytes, reserialized_bytes, "Reserialized binary is not identical to the original!");
+    }
 
     // pretty print the result (or write to a file)
     if let Some(out_path) = opt.output {

--- a/apps/bin-prot-layout-reader/src/main.rs
+++ b/apps/bin-prot-layout-reader/src/main.rs
@@ -60,6 +60,7 @@ fn main() -> Result<()> {
     // fallback to binary interpretation
     let bytes = if let Ok(hex_bytes) = hex::decode(&buffer) {
         info!("Identified HEX encoded string input");
+        println!("{:?}", hex_bytes);
         hex_bytes
     } else {
         info!("Interpreting binary as raw bytes");

--- a/protocol/bin-prot/src/error.rs
+++ b/protocol/bin-prot/src/error.rs
@@ -108,6 +108,10 @@ pub enum Error {
     #[error("Unimplemented rule")]
     UnimplementedRule,
 
+    /// When deserializing a polyvar the tag does not match any known tags for the type
+    #[error("Unrecognised Polyvar tag {0}")]
+    UnknownPolyvarTag(u32),
+
     //////////////////////////////////
     /// Some user-defined error occurred.
     #[error("{message}")]

--- a/protocol/bin-prot/src/loose_deserializer.rs
+++ b/protocol/bin-prot/src/loose_deserializer.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 
 use crate::de::{Enum, LooselyTyped, MapAccess, SeqAccess};
 use crate::error::{Error, Result};
-use crate::value::layout::{BinProtRule, Polyvar};
+use crate::value::layout::{BinProtRule, Polyvar, TaggedPolyvar};
 use crate::value::layout::Summand;
 use crate::Deserializer as DS;
 use crate::ReadBinProtExt;
@@ -50,7 +50,7 @@ impl<'de, 'a, R: Read> DS<R, LooselyTyped> {
                         self.mode
                             .layout_iter
                             .push(vec![BinProtRule::Tuple(variant_rules)]);
-                        visitor.visit_enum(ValueEnum::new(self, summands[index as usize].clone()))
+                        visitor.visit_enum(ValueEnum::new(self, VariantType::Sum(summands[index as usize].clone())))
                     }
                     BinProtRule::Polyvar(summands) => {
                         let tag = self.rdr.bin_read_polyvar_tag()?;
@@ -66,7 +66,7 @@ impl<'de, 'a, R: Read> DS<R, LooselyTyped> {
                         self.mode
                             .layout_iter
                             .push(vec![BinProtRule::Tuple(variant.clone().polyvar_args)]);                        
-                        visitor.visit_enum(ValueEnum::new(self, variant.to_summand(index)))
+                        visitor.visit_enum(ValueEnum::new(self, VariantType::Polyvar(index as u8, variant)))
                     }
                     BinProtRule::Option(some_rule) => {
                         let index = self.rdr.bin_read_variant_index()?; // 0 or 1
@@ -158,22 +158,26 @@ impl<'de, 'a, R: Read> DS<R, LooselyTyped> {
     }
 }
 
+pub enum VariantType {
+    Sum(Summand),
+    Polyvar(u8, TaggedPolyvar),
+}
+
 // for accessing enums when using the loosely typed method
 // to deserialize into a Value
 pub struct ValueEnum<'a, R: Read, Mode> {
     de: &'a mut DS<R, Mode>,
-    variant: Summand,
+    variant: VariantType,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct EnumData {
-    pub index: u8,
-    pub name: String,
-    pub len: usize,
+pub enum EnumData {
+    Sum { index: u8, name: String, len: usize },
+    Polyvar { index: u8, tag: u32, name: String, len: usize },
 }
 
 impl<'a, 'de, R: Read, Mode> ValueEnum<'a, R, Mode> {
-    fn new(de: &'a mut DS<R, Mode>, variant: Summand) -> Self {
+    fn new(de: &'a mut DS<R, Mode>, variant: VariantType) -> Self {
         Self { de, variant }
     }
 }
@@ -186,17 +190,34 @@ impl<'de, 'a, R: Read> serde::de::EnumAccess<'de> for ValueEnum<'a, R, LooselyTy
     where
         V: serde::de::DeserializeSeed<'de>,
     {
-        let index = self.variant.index;
 
         // bit of a hack here. visit_enum in the visitor is expecting to be able to
         // deserialize the enum details (e.g. variant index and name) from the stream.
         // Since in this case it comes from the layout file we need to serialize this data
         // and then return the deserializer to be handled by visit_enum
 
-        let enum_data = EnumData {
-            index: index.try_into().unwrap(),
-            name: self.variant.ctor_name,
-            len: self.variant.ctor_args.len(),
+        let (index, enum_data) = match self.variant {
+            VariantType::Sum(summand) => {
+                (
+                    summand.index as u8,
+                    EnumData::Sum {
+                        index: summand.index.try_into().unwrap(),
+                        name: summand.ctor_name,
+                        len: summand.ctor_args.len(),
+                    }
+                )
+            },
+            VariantType::Polyvar(index, polyvar) => {
+                (
+                    index,
+                    EnumData::Polyvar {
+                        index,
+                        tag: polyvar.hash.to_u32(),
+                        name: polyvar.polyvar_name,
+                        len: polyvar.polyvar_args.len(),
+                    }
+                )
+            }
         };
 
         let mut buf = Vec::<u8>::new();

--- a/protocol/bin-prot/src/loose_deserializer.rs
+++ b/protocol/bin-prot/src/loose_deserializer.rs
@@ -58,7 +58,7 @@ impl<'de, 'a, R: Read> DS<R, LooselyTyped> {
                             match v {
                                 Polyvar::Tagged(t) => {
                                     // return the first tagged variant where the tag matches
-                                    if t.hash == tag { Some((i, t)) } else { None }
+                                    if t.hash.to_u32() == tag { Some((i, t)) } else { None }
                                 }
                                 Polyvar::Inherited(_) => unimplemented!() // don't know how to handle these yet
                             }

--- a/protocol/bin-prot/src/loose_deserializer.rs
+++ b/protocol/bin-prot/src/loose_deserializer.rs
@@ -7,8 +7,8 @@ use std::io::Read;
 
 use crate::de::{Enum, LooselyTyped, MapAccess, SeqAccess};
 use crate::error::{Error, Result};
-use crate::value::layout::{BinProtRule, Polyvar, TaggedPolyvar};
 use crate::value::layout::Summand;
+use crate::value::layout::{BinProtRule, Polyvar, TaggedPolyvar};
 use crate::Deserializer as DS;
 use crate::ReadBinProtExt;
 use serde::de::Visitor;
@@ -50,23 +50,37 @@ impl<'de, 'a, R: Read> DS<R, LooselyTyped> {
                         self.mode
                             .layout_iter
                             .push(vec![BinProtRule::Tuple(variant_rules)]);
-                        visitor.visit_enum(ValueEnum::new(self, VariantType::Sum(summands[index as usize].clone())))
+                        visitor.visit_enum(ValueEnum::new(
+                            self,
+                            VariantType::Sum(summands[index as usize].clone()),
+                        ))
                     }
                     BinProtRule::Polyvar(summands) => {
                         let tag = self.rdr.bin_read_polyvar_tag()?;
-                        let (index, variant) = summands.into_iter().enumerate().find_map(|(i, v)| {
-                            match v {
-                                Polyvar::Tagged(t) => {
-                                    // return the first tagged variant where the tag matches
-                                    if t.hash.to_u32() == tag { Some((i, t)) } else { None }
+                        let (index, variant) = summands
+                            .into_iter()
+                            .enumerate()
+                            .find_map(|(i, v)| {
+                                match v {
+                                    Polyvar::Tagged(t) => {
+                                        // return the first tagged variant where the tag matches
+                                        if t.hash.to_u32() == tag {
+                                            Some((i, t))
+                                        } else {
+                                            None
+                                        }
+                                    }
+                                    Polyvar::Inherited(_) => unimplemented!(), // don't know how to handle these yet
                                 }
-                                Polyvar::Inherited(_) => unimplemented!() // don't know how to handle these yet
-                            }
-                        }).ok_or(Error::UnknownPolyvarTag(tag))?;
+                            })
+                            .ok_or(Error::UnknownPolyvarTag(tag))?;
                         self.mode
                             .layout_iter
-                            .push(vec![BinProtRule::Tuple(variant.clone().polyvar_args)]);                        
-                        visitor.visit_enum(ValueEnum::new(self, VariantType::Polyvar(index as u8, variant)))
+                            .push(vec![BinProtRule::Tuple(variant.clone().polyvar_args)]);
+                        visitor.visit_enum(ValueEnum::new(
+                            self,
+                            VariantType::Polyvar(index as u8, variant),
+                        ))
                     }
                     BinProtRule::Option(some_rule) => {
                         let index = self.rdr.bin_read_variant_index()?; // 0 or 1
@@ -172,8 +186,17 @@ pub struct ValueEnum<'a, R: Read, Mode> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum EnumData {
-    Sum { index: u8, name: String, len: usize },
-    Polyvar { index: u8, tag: u32, name: String, len: usize },
+    Sum {
+        index: u8,
+        name: String,
+        len: usize,
+    },
+    Polyvar {
+        index: u8,
+        tag: u32,
+        name: String,
+        len: usize,
+    },
 }
 
 impl<'a, 'de, R: Read, Mode> ValueEnum<'a, R, Mode> {
@@ -190,34 +213,29 @@ impl<'de, 'a, R: Read> serde::de::EnumAccess<'de> for ValueEnum<'a, R, LooselyTy
     where
         V: serde::de::DeserializeSeed<'de>,
     {
-
         // bit of a hack here. visit_enum in the visitor is expecting to be able to
         // deserialize the enum details (e.g. variant index and name) from the stream.
         // Since in this case it comes from the layout file we need to serialize this data
         // and then return the deserializer to be handled by visit_enum
 
         let (index, enum_data) = match self.variant {
-            VariantType::Sum(summand) => {
-                (
-                    summand.index as u8,
-                    EnumData::Sum {
-                        index: summand.index.try_into().unwrap(),
-                        name: summand.ctor_name,
-                        len: summand.ctor_args.len(),
-                    }
-                )
-            },
-            VariantType::Polyvar(index, polyvar) => {
-                (
+            VariantType::Sum(summand) => (
+                summand.index as u8,
+                EnumData::Sum {
+                    index: summand.index.try_into().unwrap(),
+                    name: summand.ctor_name,
+                    len: summand.ctor_args.len(),
+                },
+            ),
+            VariantType::Polyvar(index, polyvar) => (
+                index,
+                EnumData::Polyvar {
                     index,
-                    EnumData::Polyvar {
-                        index,
-                        tag: polyvar.hash.to_u32(),
-                        name: polyvar.polyvar_name,
-                        len: polyvar.polyvar_args.len(),
-                    }
-                )
-            }
+                    tag: polyvar.hash.to_u32(),
+                    name: polyvar.polyvar_name,
+                    len: polyvar.polyvar_args.len(),
+                },
+            ),
         };
 
         let mut buf = Vec::<u8>::new();

--- a/protocol/bin-prot/src/loose_deserializer.rs
+++ b/protocol/bin-prot/src/loose_deserializer.rs
@@ -243,6 +243,6 @@ impl<'de, 'a, R: Read> serde::de::EnumAccess<'de> for ValueEnum<'a, R, LooselyTy
         let mut de = DS::from_reader(buf.as_slice());
         let v = seed.deserialize(&mut de)?;
 
-        Ok((v, Enum::new(self.de, index.try_into().unwrap())))
+        Ok((v, Enum::new(self.de, index)))
     }
 }

--- a/protocol/bin-prot/src/read_ext.rs
+++ b/protocol/bin-prot/src/read_ext.rs
@@ -112,7 +112,6 @@ pub trait ReadBinProtExt: io::Read {
     fn bin_read_polyvar_tag(&mut self) -> Result<u32> {
         let mut buf = [0_u8; 4];
         self.read_exact(&mut buf)?;
-        println!("Reading polyvar tag {} = {:?}", u32::from_le_bytes(buf), &buf);
         Ok(u32::from_le_bytes(buf))
     }
 

--- a/protocol/bin-prot/src/read_ext.rs
+++ b/protocol/bin-prot/src/read_ext.rs
@@ -108,6 +108,14 @@ pub trait ReadBinProtExt: io::Read {
         self.read_u8().map_err(Error::Io)
     }
 
+    /// Read the tag of a polyvar variant (4 bytes)
+    fn bin_read_polyvar_tag(&mut self) -> Result<u32> {
+        let mut buf = [0_u8; 4];
+        self.read_exact(&mut buf)?;
+        println!("Reading polyvar tag {} = {:?}", u32::from_le_bytes(buf), &buf);
+        Ok(u32::from_le_bytes(buf))
+    }
+
     /// Read a string
     fn bin_read_string(&mut self) -> Result<String> {
         let len = self.bin_read_nat0::<u64>()? as usize;

--- a/protocol/bin-prot/src/ser.rs
+++ b/protocol/bin-prot/src/ser.rs
@@ -41,12 +41,10 @@ where
     fn write_variant_index_or_tag(&mut self, index: u32) -> Result<()> {
         if let Ok(b) = check_variant_index(index) {
             // it is a sum variant
-            self.writer
-            .bin_write_variant_index(b)?;
+            self.writer.bin_write_variant_index(b)?;
         } else {
             // assume it is a Polyvar tagged variant
-            self.writer
-            .bin_write_polyvar_tag(index)?;
+            self.writer.bin_write_polyvar_tag(index)?;
         }
         Ok(())
     }

--- a/protocol/bin-prot/src/ser.rs
+++ b/protocol/bin-prot/src/ser.rs
@@ -32,6 +32,24 @@ where
     fn write_byte(&mut self, b: u8) -> Result<()> {
         self.write(&[b])
     }
+
+    // This can be called to serialize a Polyvar which has a 4 byte
+    // tag OR a variant index which is 1-2 bytes. We assume if they fit into a single byte then they
+    // are an index and if they are larger than 1 byte they are a polyvar.
+    // IMPORTANT: This could bug out in the case that a polyvar hash is zero in all places except the lowest byte.
+    // The probability of this happening is vanishingly small but something to be aware of.
+    fn write_variant_index_or_tag(&mut self, index: u32) -> Result<()> {
+        if let Ok(b) = check_variant_index(index) {
+            // it is a sum variant
+            self.writer
+            .bin_write_variant_index(b)?;
+        } else {
+            // assume it is a Polyvar tagged variant
+            self.writer
+            .bin_write_polyvar_tag(index)?;
+        }
+        Ok(())
+    }
 }
 
 /// Convenience function, creates  serializer and uses it to write the given value
@@ -253,9 +271,7 @@ where
         variant_index: u32,
         _variant: &'static str,
     ) -> Result<()> {
-        self.writer
-            .bin_write_variant_index(check_variant_index(variant_index)?)?;
-        Ok(())
+        self.write_variant_index_or_tag(variant_index)
     }
 
     fn serialize_tuple_variant(
@@ -265,8 +281,7 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        self.writer
-            .bin_write_variant_index(check_variant_index(variant_index)?)?;
+        self.write_variant_index_or_tag(variant_index)?;
         Ok(self)
     }
 
@@ -277,8 +292,7 @@ where
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        self.writer
-            .bin_write_variant_index(check_variant_index(variant_index)?)?;
+        self.write_variant_index_or_tag(variant_index)?;
         Ok(self)
     }
 
@@ -293,8 +307,7 @@ where
     where
         T: ?Sized + Serialize,
     {
-        self.writer
-            .bin_write_variant_index(check_variant_index(variant_index)?)?;
+        self.write_variant_index_or_tag(variant_index)?;
         value.serialize(self)
     }
 }

--- a/protocol/bin-prot/src/value/layout/mod.rs
+++ b/protocol/bin-prot/src/value/layout/mod.rs
@@ -191,19 +191,6 @@ pub enum Polyvar {
     Inherited(BinProtRule),
 }
 
-impl TaggedPolyvar {
-    /// Convert a tagged polyvar to a summand since Rust has no concept of polvar types
-    /// they can be represented as an enum instead for now
-    /// Note: This is not perfect since it means round-trips are not possible!
-    pub fn to_summand(self, index: usize) -> Summand {
-        Summand {
-            ctor_name: self.polyvar_name,
-            index: index as i32,
-            ctor_args: self.polyvar_args,
-        }
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// A polyvar hash identifies a variant in a polyvar rather than
 /// an index in a sum type

--- a/protocol/bin-prot/src/value/layout/mod.rs
+++ b/protocol/bin-prot/src/value/layout/mod.rs
@@ -191,12 +191,29 @@ pub enum Polyvar {
     Inherited(BinProtRule),
 }
 
+impl TaggedPolyvar {
+    /// Convert a tagged polyvar to a summand since Rust has no concept of polvar types
+    /// they can be represented as an enum instead for now
+    /// Note: This is not perfect since it means round-trips are not possible!
+    pub fn to_summand(self, index: usize) -> Summand {
+        Summand {
+            ctor_name: self.polyvar_name,
+            index: index as i32,
+            ctor_args: self.polyvar_args,
+        }
+    }
+}
+
+/// 4 bytes hash used to identify a variant of a polyvar
+/// These are used instead of an index as in sum types
+pub type PolyvarTag = u32;
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// τ ≤ Γ(a), τ is an instance of Γ(a) and (Γ(a) a type scheme
 pub struct TaggedPolyvar {
-    polyvar_name: String,
-    hash: i32,
-    polyvar_args: Vec<BinProtRule>,
+    pub(crate) polyvar_name: String,
+    pub(crate) hash: PolyvarTag,
+    pub(crate) polyvar_args: Vec<BinProtRule>,
 }
 
 impl TryFrom<ListTaggedEnum> for Polyvar {

--- a/protocol/bin-prot/src/value/layout/mod.rs
+++ b/protocol/bin-prot/src/value/layout/mod.rs
@@ -204,9 +204,21 @@ impl TaggedPolyvar {
     }
 }
 
-/// 4 bytes hash used to identify a variant of a polyvar
-/// These are used instead of an index as in sum types
-pub type PolyvarTag = u32;
+#[derive(Clone, Serialize, Deserialize, Debug)]
+/// A polyvar hash identifies a variant in a polyvar rather than
+/// an index in a sum type
+/// This is encoded in the layout JSON files as an OCaml 63 bit integer
+/// and some special care needs to be taken when coverting between
+pub struct PolyvarTag(u32);
+
+impl PolyvarTag {
+    /// The integers format used to serialize the JSON layouts uses 63 bit integers
+    /// so if we read the bytes from the binary and try and compare they are off by a 1 bit shift.
+    /// This function convers to a rust style integer representation for comparison
+    pub fn to_u32(&self) -> u32 {
+        self.0 << 1 | 1
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// τ ≤ Γ(a), τ is an instance of Γ(a) and (Γ(a) a type scheme

--- a/protocol/bin-prot/src/value/layout/traverse.rs
+++ b/protocol/bin-prot/src/value/layout/traverse.rs
@@ -47,16 +47,13 @@ impl Iterator for BinProtRuleIterator {
                     BinProtRule::Tuple(mut rules) => {
                         self.stack.extend(rules.drain(0..).rev());
                     }
-                    BinProtRule::Sum(_summands) => {
+                    BinProtRule::Sum(_)
+                    | BinProtRule::Polyvar(_) => {
                         // don't add to the stack. Add to the branch field instead
                         // this must be resolved by calling `branch` before the iterator can continue
                     }
                     BinProtRule::Option(_r) => {
                         // Option is a special case of a Sum where the None variant contain nothing
-                    }
-                    BinProtRule::Polyvar(_polyvars) => {
-                        // these are pretty much anonymous enum/sum types and should be handled the same way
-                        unimplemented!();
                     }
                     BinProtRule::Reference(rule_ref) => match rule_ref {
                         RuleRef::Unresolved(_payload) => {

--- a/protocol/bin-prot/src/value/layout/traverse.rs
+++ b/protocol/bin-prot/src/value/layout/traverse.rs
@@ -47,8 +47,7 @@ impl Iterator for BinProtRuleIterator {
                     BinProtRule::Tuple(mut rules) => {
                         self.stack.extend(rules.drain(0..).rev());
                     }
-                    BinProtRule::Sum(_)
-                    | BinProtRule::Polyvar(_) => {
+                    BinProtRule::Sum(_) | BinProtRule::Polyvar(_) => {
                         // don't add to the stack. Add to the branch field instead
                         // this must be resolved by calling `branch` before the iterator can continue
                     }

--- a/protocol/bin-prot/src/value/mod.rs
+++ b/protocol/bin-prot/src/value/mod.rs
@@ -52,6 +52,15 @@ pub enum Value {
         /// value wrapped by variant
         value: Box<Value>,
     },
+    /// Polymorphic Variant (Polyvar) types
+    Polyvar {
+        /// Polyvar variant name
+        name: String,
+        /// Polyvar variant tag (e.g. hash)
+        tag: u32,
+        /// value wrapped by variant
+        value: Box<Value>
+    },
     /// List of types (variable length)
     List(Vec<Value>),
 }

--- a/protocol/bin-prot/src/value/mod.rs
+++ b/protocol/bin-prot/src/value/mod.rs
@@ -59,7 +59,7 @@ pub enum Value {
         /// Polyvar variant tag (e.g. hash)
         tag: u32,
         /// value wrapped by variant
-        value: Box<Value>
+        value: Box<Value>,
     },
     /// List of types (variable length)
     List(Vec<Value>),

--- a/protocol/bin-prot/src/value/ser.rs
+++ b/protocol/bin-prot/src/value/ser.rs
@@ -52,7 +52,7 @@ impl Serialize for Value {
             Value::Polyvar {
                 name: _,
                 ref tag,
-                ref value
+                ref value,
             } => serializer.serialize_newtype_variant("", *tag as u32, "", value), // sum types/enums
             Value::List(ref v) => v.serialize(serializer),
         }

--- a/protocol/bin-prot/src/value/ser.rs
+++ b/protocol/bin-prot/src/value/ser.rs
@@ -49,6 +49,11 @@ impl Serialize for Value {
                 ref index,
                 ref value,
             } => serializer.serialize_newtype_variant("", *index as u32, "", value), // sum types/enums
+            Value::Polyvar {
+                name: _,
+                ref tag,
+                ref value
+            } => serializer.serialize_newtype_variant("", *tag as u32, "", value), // sum types/enums
             Value::List(ref v) => v.serialize(serializer),
         }
     }

--- a/protocol/bin-prot/src/value/visitor.rs
+++ b/protocol/bin-prot/src/value/visitor.rs
@@ -115,15 +115,20 @@ impl<'de> Visitor<'de> for ValueVisitor {
         // the variant access can be used to retrieve the correct content based on this
 
         match payload {
-            EnumData::Sum{index, name, len} => {
+            EnumData::Sum { index, name, len } => {
                 let body = variant_access.tuple_variant(len, self)?;
                 Ok(Value::Sum {
                     name,
                     index,
                     value: Box::new(body),
                 })
-            },
-            EnumData::Polyvar{ index: _, tag, name, len } => {
+            }
+            EnumData::Polyvar {
+                index: _,
+                tag,
+                name,
+                len,
+            } => {
                 let body = variant_access.tuple_variant(len, self)?;
                 Ok(Value::Polyvar {
                     name,

--- a/protocol/bin-prot/src/value/visitor.rs
+++ b/protocol/bin-prot/src/value/visitor.rs
@@ -114,12 +114,23 @@ impl<'de> Visitor<'de> for ValueVisitor {
         // payload must encode the index and name in a deserializer
         // the variant access can be used to retrieve the correct content based on this
 
-        let body = variant_access.tuple_variant(payload.len, self)?;
-
-        Ok(Value::Sum {
-            name: payload.name,
-            index: payload.index,
-            value: Box::new(body),
-        })
+        match payload {
+            EnumData::Sum{index, name, len} => {
+                let body = variant_access.tuple_variant(len, self)?;
+                Ok(Value::Sum {
+                    name,
+                    index,
+                    value: Box::new(body),
+                })
+            },
+            EnumData::Polyvar{ index: _, tag, name, len } => {
+                let body = variant_access.tuple_variant(len, self)?;
+                Ok(Value::Polyvar {
+                    name,
+                    tag,
+                    value: Box::new(body),
+                })
+            }
+        }
     }
 }

--- a/protocol/bin-prot/src/write_ext.rs
+++ b/protocol/bin-prot/src/write_ext.rs
@@ -119,6 +119,11 @@ pub trait WriteBinProtExt: io::Write {
     fn bin_write_variant_index(&mut self, i: u8) -> Result<usize, io::Error> {
         self.write_u8(i).map(|_| 1) // truncating downcast
     }
+
+    /// For Polyvar types write the 4 bytes of the tag/hash for a variant
+    fn bin_write_polyvar_tag(&mut self, i: u32) -> Result<usize, io::Error> {
+        self.write(&i.to_le_bytes()).map(|_| 4) // truncating downcast
+    }
 }
 
 /// All types that implement `Write` get methods defined in `WriteBinProtIntegerExt`

--- a/protocol/bin-prot/tests/layouts.rs
+++ b/protocol/bin-prot/tests/layouts.rs
@@ -139,6 +139,48 @@ mod tests {
         test_reserialize(&result, &example);
     }
 
+    const TAGGED_POLYVAR_RULE: &str = r#"
+[
+  "Polyvar",
+   [
+    [
+     "Tagged",
+     {
+      "polyvar_name": "One",
+      "hash": 3953222,
+      "polyvar_args": [["Int"]]
+     }
+    ],
+    [
+     "Tagged",
+     {
+      "polyvar_name": "Two",
+      "hash": 4203884,
+      "polyvar_args": [["Bool"]]
+     }
+    ]
+   ]
+]
+"#;
+
+    #[test]
+    fn test_tagged_polyvar_rule() {
+        let rule: BinProtRule = serde_json::from_str(TAGGED_POLYVAR_RULE).unwrap();
+        let example = vec![0xd9, 0x4a, 0x80, 0x00, 0x01]; // Two((true))
+
+        let mut de = Deserializer::from_reader(Cursor::new(example.as_slice())).with_layout(&rule);
+        let result: Value = Deserialize::deserialize(&mut de).expect("Failed to deserialize");
+        assert_eq!(
+            result,
+            Value::Polyvar {
+                name: "Two".to_string(),
+                tag: 8407769, // Note this is different to the json encoded version which uses OCaml 63 bit encoding. You can convert between using (x << 1 | 1)
+                value: Box::new(Value::Tuple(vec![Value::Bool(true)]))
+            }
+        );
+        test_reserialize(&result, &example);
+    }
+
     const NESTED_SUM_RULE: &str = r#"
 [
   "Sum",


### PR DESCRIPTION
Some Mina data structures use a Polymorphic Variant (Polyvar) data structure. These are much like Sum types / enums but identify variants with a hash rather than an index when serialized. This hash needs to be stored along with the variant in a special data structure since Rust has no equivalent data type. 

**Summary of changes**
Changes introduced in this pull request:
- Adds deserialization support for Polyvars from loosely typed layouts
- Add serialization support for polyvars from loose types
- (TODO) Add data type to represent polyvars in Rust to strong type serialization and deserialization


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->