### PR TITLE
M2: Setup basic peer initialization stubs: Initialize consensus step

### DIFF
--- a/consensus/src/common.rs
+++ b/consensus/src/common.rs
@@ -3,11 +3,14 @@
 
 //! Implements common APIs for the blockchain in the context of consensus.
 
+use std::collections::HashMap;
+
 use hex::ToHex;
 use mina_crypto::hash::{Hashable, StateHash};
 use mina_rs_base::consensus_state::ConsensusState;
 use mina_rs_base::global_slot::GlobalSlot;
 use mina_rs_base::protocol_state::{Header, ProtocolState};
+use mina_rs_base::types::ExternalTransition;
 
 use crate::checkpoint::is_short_range;
 use crate::density::{relative_min_window_density, ConsensusConstants};
@@ -179,4 +182,34 @@ impl Consensus for ProtocolStateChain {
 
         Ok(self)
     }
+}
+
+struct ForkTree<T> {
+    tree: Vec<T>,
+}
+
+impl<T> ForkTree<T> {
+    fn new() -> Self {
+        Self { tree: vec![] }
+    }
+}
+
+struct Peer {
+    genesis_block: ExternalTransition,
+    neighbours: HashMap<String, Peer>,
+    chains: ForkTree<ProtocolStateChain>,
+    tip: Option<ProtocolStateChain>,
+}
+
+impl Peer {
+    fn bootstrap() {
+        // TODO: load genesis block
+    }
+
+    fn catchup() {
+        // TODO: integrate select secure chain
+    }
+
+    // Top level API for Peer initialization
+    fn init() {}
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Creates a Peer entity that is responsible for connecting to peers and initalizing the node bootstrap sequence.
- Eventually calls the select chain API as part of its lifecycle method. [TODO]

Notes:
- We don't intend to implement the transition frontier in the peer as of now as it's still in flux.

Ref: https://github.com/MinaProtocol/mina/blob/02dfc3ff0160ba3c1bbc732baa07502fe4312b04/docs/specs/consensus/README.md#61-initialize-consensus

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #89


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->