### PR TITLE
adds caml_variant_hash port of c code

### DIFF
--- a/protocol/bin-prot/src/lib.rs
+++ b/protocol/bin-prot/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod integers;
 #[cfg(feature = "loose_deserialization")]
 mod loose_deserializer;
+mod polyvar;
 mod read_ext;
 mod ser;
 pub mod value;
@@ -20,6 +21,7 @@ mod write_ext;
 
 // pub use array::OcamlArray;
 pub use de::{from_reader, Deserializer};
+pub use polyvar::{caml_hash_variant, PolyVar, VariantHash};
 pub use read_ext::ReadBinProtExt;
 pub use ser::{to_writer, Serializer};
 #[cfg(feature = "loose_deserialization")]

--- a/protocol/bin-prot/src/polyvar/caml_hash_variant.rs
+++ b/protocol/bin-prot/src/polyvar/caml_hash_variant.rs
@@ -1,0 +1,45 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0
+
+//! OCaml polyvars use a special integer output hash function to index variants
+//! This module reimplements this hash function
+
+/// Type alias for hash result
+pub type VariantHash = u32;
+
+/// Hash the label string (ASCII not UTF-8) into a OCaml style variant hash
+pub fn caml_hash_variant(label: &[u8]) -> VariantHash {
+    label
+        .iter()
+        .fold(0_u32, |accu, byte| 223 * accu + (*byte as u32))
+}
+
+/* original C code
+    CAMLexport value caml_hash_variant(char const * tag)
+    {
+      value accu;
+      /* Same hashing algorithm as in ../typing/btype.ml, function hash_variant */
+      for (accu = Val_int(0); *tag != 0; tag++)
+        accu = Val_int(223 * Int_val(accu) + *((unsigned char *) tag));
+    #ifdef ARCH_SIXTYFOUR
+      accu = accu & Val_long(0x7FFFFFFFL);
+    #endif
+      /* Force sign extension of bit 31 for compatibility between 32 and 64-bit
+         platforms */
+      return (int32_t) accu;
+    }
+*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_labels() {
+        const CASES: &[(&[u8], u32)] = &[(b"One", 3953222_u32), (b"Two", 4203884_u32)];
+
+        for (label, hash) in CASES {
+            assert_eq!(caml_hash_variant(label), *hash)
+        }
+    }
+}

--- a/protocol/bin-prot/src/polyvar/mod.rs
+++ b/protocol/bin-prot/src/polyvar/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0
+
+//! Adds support for serializing and deserializing polyvars as Rust enums
+
+use serde::{Deserialize, Serialize};
+
+mod caml_hash_variant;
+pub use caml_hash_variant::{caml_hash_variant, VariantHash};
+
+/// A polymorphic variant as it should be serialized, the variant hash followed by the body.
+/// The default implementations of Serialize and Deserialize work for this.
+#[derive(Serialize, Deserialize)]
+pub struct PolyVar<T> {
+    /// The variant hash computed by using `caml_hash_variant` on its label
+    hash: VariantHash,
+    /// The body associated with the variant. Can be empty.
+    body: T,
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Adds the `caml_hash_variant` function which replicates the hash algorithm used by OCaml to convert variant labels to strings
- Adds generic `Polyvar` struct which should serialize the same as a polyvar when used via bin-prot

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->

Supporting work for #185  


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->