### PR TITLE
M4 - Implement Hashable for num types in Account

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,8 +36,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # Pin rust nightly until https://github.com/briansmith/ring/issues/1469 is resolved.
-          toolchain: nightly-2022-03-22
+          toolchain: nightly
           target: wasm32-unknown-unknown
           override: false
       - run: cargo fmt --all -- --check
@@ -58,9 +57,9 @@ jobs:
           command: check All -s
           arguments: --all-features --manifest-path apps/wasm/Cargo.toml
       - run: cargo install cargo-udeps || echo 'already installed'
-      - run: cargo +nightly-2022-03-22 udeps --all-targets --all-features
-      - run: cargo +nightly-2022-03-22 udeps --all-targets --all-features --manifest-path apps/Cargo.toml
-      - run: cargo +nightly-2022-03-22 udeps --target wasm32-unknown-unknown --all-features --manifest-path apps/wasm/Cargo.toml
+      - run: cargo +nightly udeps --all-targets --all-features
+      - run: cargo +nightly udeps --all-targets --all-features --manifest-path apps/Cargo.toml
+      - run: cargo +nightly udeps --target wasm32-unknown-unknown --all-features --manifest-path apps/wasm/Cargo.toml
   x86_64:
     runs-on: ubuntu-latest
     steps:
@@ -201,8 +200,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # Pin rust nightly until https://github.com/briansmith/ring/issues/1469 is resolved.
-          toolchain: nightly-2022-03-22
+          toolchain: nightly
           override: true
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "merkle",
   "network",
   "ledger",
+  "proof-systems-shim",
   "protocol/bin-prot",
   "protocol/bin_prot_checker",
   "protocol/test-fixtures",

--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -38,17 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alga"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
-dependencies = [
- "approx",
- "num-complex 0.2.4",
- "num-traits 0.2.14",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,15 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
-name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits 0.2.14",
-]
-
-[[package]]
 name = "ark-ec"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +62,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "num-traits 0.2.14",
+ "num-traits",
  "rayon",
  "zeroize",
 ]
@@ -99,7 +79,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "num-bigint",
- "num-traits 0.2.14",
+ "num-traits",
  "paste",
  "rayon",
  "rustc_version 0.3.3",
@@ -123,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.14",
+ "num-traits",
  "quote",
  "syn",
 ]
@@ -170,16 +150,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
  "rand",
  "rayon",
 ]
 
 [[package]]
 name = "array-init"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51c983d65b6691893a791e55aa8bda43bbd9b11f947e5a9581710362277cc95"
+checksum = "6945cc5422176fc5e602e590c2878d2c2acd9a4fe20a4baa7c28022521698ec6"
 
 [[package]]
 name = "atty"
@@ -220,6 +200,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bcs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510fd83e3eaf7263b06182f3550b4c0af2af42cb36ab8024969ff5ea7fcb2833"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "bin-prot"
 version = "0.1.0"
 dependencies = [
@@ -252,14 +242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "blake2"
-version = "0.9.2"
+name = "bitvec"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
 dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug",
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -295,7 +286,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -339,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "c67e7973e74896f4bba06ca2dcfd28d54f9cb8c035e940a32b88ed48f5f5ecf2"
 dependencies = [
  "atty",
  "bitflags",
@@ -353,35 +344,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "commitment_dlog"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=6af257b793d80f900675acc01b16fd4bf6375268#6af257b793d80f900675acc01b16fd4bf6375268"
+source = "git+https://github.com/o1-labs/proof-systems?rev=56517b55920ea7afc811baa541c859dadc8ae50a#56517b55920ea7afc811baa541c859dadc8ae50a"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
  "array-init",
- "blake2 0.9.2",
- "colored",
+ "blake2",
  "groupmap",
  "itertools",
  "mina-curves",
  "o1-utils",
  "oracle",
  "rand",
- "rand_core 0.6.3",
+ "rand_core",
  "rayon",
  "serde",
  "serde_with",
@@ -455,16 +434,6 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -598,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +604,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 [[package]]
 name = "groupmap"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=6af257b793d80f900675acc01b16fd4bf6375268#6af257b793d80f900675acc01b16fd4bf6375268"
+source = "git+https://github.com/o1-labs/proof-systems?rev=56517b55920ea7afc811baa541c859dadc8ae50a#56517b55920ea7afc811baa541c859dadc8ae50a"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -683,9 +658,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -702,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -737,17 +712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
-name = "libm"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
-
-[[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -758,15 +728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "matrixmultiply"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
-dependencies = [
- "rawpointer",
 ]
 
 [[package]]
@@ -790,7 +751,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bin-prot",
- "blake2 0.10.4",
+ "blake2",
  "bs58",
  "derive_deref",
  "derive_more",
@@ -805,10 +766,23 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=6af257b793d80f900675acc01b16fd4bf6375268#6af257b793d80f900675acc01b16fd4bf6375268"
+source = "git+https://github.com/o1-labs/proof-systems?rev=56517b55920ea7afc811baa541c859dadc8ae50a#56517b55920ea7afc811baa541c859dadc8ae50a"
 dependencies = [
  "ark-ec",
  "ark-ff",
+]
+
+[[package]]
+name = "mina-hasher"
+version = "0.1.0"
+source = "git+https://github.com/o1-labs/proof-systems?rev=56517b55920ea7afc811baa541c859dadc8ae50a#56517b55920ea7afc811baa541c859dadc8ae50a"
+dependencies = [
+ "ark-ff",
+ "bitvec",
+ "mina-curves",
+ "o1-utils",
+ "oracle",
+ "serde",
 ]
 
 [[package]]
@@ -819,17 +793,14 @@ dependencies = [
  "ark-ff",
  "base64",
  "bin-prot",
- "commitment_dlog",
  "derive_deref",
  "derive_more",
  "getrandom",
  "hex",
  "mina-crypto",
- "mina-curves",
  "mina-serialization-types",
  "num",
- "plonk_circuits",
- "plonk_protocol_dlog",
+ "proof-systems",
  "serde",
  "thiserror",
  "time",
@@ -842,7 +813,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bin-prot",
- "clap 3.1.6",
+ "clap 3.1.7",
  "dhat",
  "mina-rs-base",
  "serde",
@@ -868,30 +839,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndarray"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
-dependencies = [
- "matrixmultiply",
- "num-complex 0.2.4",
- "num-integer",
- "num-traits 0.2.14",
- "rawpointer",
-]
-
-[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-bigint",
- "num-complex 0.4.0",
+ "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -902,17 +860,7 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -921,18 +869,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "num-traits",
 ]
 
 [[package]]
@@ -942,7 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -953,7 +890,7 @@ checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -965,16 +902,7 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -984,7 +912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1009,15 +936,19 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=6af257b793d80f900675acc01b16fd4bf6375268#6af257b793d80f900675acc01b16fd4bf6375268"
+source = "git+https://github.com/o1-labs/proof-systems?rev=56517b55920ea7afc811baa541c859dadc8ae50a#56517b55920ea7afc811baa541c859dadc8ae50a"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
  "ark-serialize",
+ "bcs",
+ "hex",
  "rayon",
  "serde",
  "serde_with",
+ "sha2 0.10.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -1044,20 +975,16 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "oracle"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=6af257b793d80f900675acc01b16fd4bf6375268#6af257b793d80f900675acc01b16fd4bf6375268"
+source = "git+https://github.com/o1-labs/proof-systems?rev=56517b55920ea7afc811baa541c859dadc8ae50a#56517b55920ea7afc811baa541c859dadc8ae50a"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
- "ark-serialize",
- "hex",
  "mina-curves",
- "num-bigint",
  "o1-utils",
  "rand",
  "rayon",
  "serde",
- "serde_json",
  "serde_with",
 ]
 
@@ -1111,45 +1038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plonk_circuits"
-version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=6af257b793d80f900675acc01b16fd4bf6375268#6af257b793d80f900675acc01b16fd4bf6375268"
-dependencies = [
- "ark-ff",
- "ark-poly",
- "array-init",
- "blake2 0.9.2",
- "mina-curves",
- "num-derive",
- "num-traits 0.2.14",
- "o1-utils",
- "oracle",
- "rand_core 0.5.1",
- "rayon",
-]
-
-[[package]]
-name = "plonk_protocol_dlog"
-version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=6af257b793d80f900675acc01b16fd4bf6375268#6af257b793d80f900675acc01b16fd4bf6375268"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "array-init",
- "colored",
- "commitment_dlog",
- "mina-curves",
- "o1-utils",
- "oracle",
- "plonk_circuits",
- "rand",
- "rand_core 0.6.3",
- "rayon",
- "sprs",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1077,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proof-systems"
+version = "0.1.0"
+dependencies = [
+ "commitment_dlog",
+ "mina-hasher",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +1116,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1224,14 +1126,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -1241,12 +1137,6 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -1275,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -1449,22 +1339,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
-name = "sprs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec63571489873d4506683915840eeb1bb16b3198ee4894cc6f2fe3013d505e56"
-dependencies = [
- "alga",
- "ndarray",
- "num-complex 0.2.4",
- "num-traits 0.1.43",
-]
 
 [[package]]
 name = "stacker"
@@ -1523,9 +1412,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1543,6 +1432,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -1743,6 +1638,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zeroize"

--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.7"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c67e7973e74896f4bba06ca2dcfd28d54f9cb8c035e940a32b88ed48f5f5ecf2"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+checksum = "4e92cb285610dd935f60ee8b4d62dd1988bd12b7ea50579bd6a138201525318e"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+checksum = "5c29e95ab498b18131ea460b2c0baa18cbf041231d122b0b7bfebef8c8e88989"
 dependencies = [
  "fnv",
  "ident_case",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+checksum = "b21dd6b221dd547528bd6fb15f1a3b7ab03b9a06f76bff288a8c629bcfbe7f0e"
 dependencies = [
  "darling_core",
  "quote",
@@ -813,7 +813,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bin-prot",
- "clap 3.1.7",
+ "clap 3.1.8",
  "dhat",
  "mina-rs-base",
  "serde",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eca0fa5dd7c4c96e184cec588f0b1db1ee3165e678db21c09793105acb17e6f"
+checksum = "871372391786ccec00d3c5d3d6608905b3d4db263639cfe075d3b60a736d115a"
 dependencies = [
  "cc",
 ]

--- a/apps/wasm/Cargo.lock
+++ b/apps/wasm/Cargo.lock
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb87f3080f6d1d69e8c564c0fcfde1d7aa8cc451ce40cae89479111f03bc0eb"
+checksum = "22e8810f0ab5b02d4fc737c818258c8560a3216b7ebd5fd756cb437e23157fc6"
 dependencies = [
  "hashbrown",
 ]
@@ -2712,9 +2712,9 @@ checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"

--- a/apps/wasm/Cargo.lock
+++ b/apps/wasm/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
+checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1699,10 +1699,11 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1849,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7392bffd88bc0c4f8297e36a777ab9f80b7127409c4a1acb8fee99c9f27addcd"
+checksum = "e3db354f401db558759dfc1e568d010a5d4146f4d3f637be1275ec4a3cf09689"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
@@ -2052,7 +2053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -2071,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2164,9 +2165,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
@@ -2456,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -2801,9 +2802,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3292,15 +3293,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
- "windows_aarch64_msvc 0.32.0",
- "windows_i686_gnu 0.32.0",
- "windows_i686_msvc 0.32.0",
- "windows_x86_64_gnu 0.32.0",
- "windows_x86_64_msvc 0.32.0",
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
 ]
 
 [[package]]
@@ -3311,9 +3312,9 @@ checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3323,9 +3324,9 @@ checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3335,9 +3336,9 @@ checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3347,9 +3348,9 @@ checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3359,9 +3360,9 @@ checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-mina-crypto = {path = "../crypto"}
 bin-prot = {path = "../protocol/bin-prot"}
+mina-crypto = {path = "../crypto"}
 mina-serialization-types = {path = "../protocol/serialization-types"}
 versioned = {path = "../protocol/versioned"}
 
+ark-ec = "0.3.0"
+ark-ff = "0.3.0"
 base64 = "0.13"
 derive_deref = "1.1"
 derive_more = "0.99"
@@ -21,12 +23,8 @@ serde = {version = "1", features = ["derive"]}
 thiserror = "1"
 time = "0.3"
 
-ark-ec = "0.3.0"
-ark-ff = "0.3.0"
-commitment_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "6af257b793d80f900675acc01b16fd4bf6375268"}
-mina-curves = {git = "https://github.com/o1-labs/proof-systems", rev = "6af257b793d80f900675acc01b16fd4bf6375268"}
-plonk_circuits = {git = "https://github.com/o1-labs/proof-systems", rev = "6af257b793d80f900675acc01b16fd4bf6375268"}
-plonk_protocol_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "6af257b793d80f900675acc01b16fd4bf6375268"}
+commitment_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "3f5f90d190f537857c800a9aeb349bff2132d175"}
+mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "3f5f90d190f537857c800a9aeb349bff2132d175"}
 
 # This dependency is not used by the crate, but is a subdependency of commitment_dlog
 # This features must be enable to build with WASM support
@@ -35,4 +33,4 @@ plonk_protocol_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "
 getrandom = {version = "0.2", features = ["js"]}
 
 [dev-dependencies]
-test-fixtures = { path = "../protocol/test-fixtures" }
+test-fixtures = {path = "../protocol/test-fixtures"}

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -11,6 +11,7 @@ bin-prot = {path = "../protocol/bin-prot"}
 mina-crypto = {path = "../crypto"}
 mina-serialization-types = {path = "../protocol/serialization-types"}
 versioned = {path = "../protocol/versioned"}
+proof-systems = {path = "../proof-systems-shim"}
 
 ark-ec = "0.3.0"
 ark-ff = "0.3.0"
@@ -22,9 +23,6 @@ num = "0.4"
 serde = {version = "1", features = ["derive"]}
 thiserror = "1"
 time = "0.3"
-
-commitment_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "56517b55920ea7afc811baa541c859dadc8ae50a"}
-mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "56517b55920ea7afc811baa541c859dadc8ae50a"}
 
 # This dependency is not used by the crate, but is a subdependency of commitment_dlog
 # This features must be enable to build with WASM support

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -23,8 +23,8 @@ serde = {version = "1", features = ["derive"]}
 thiserror = "1"
 time = "0.3"
 
-commitment_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "3f5f90d190f537857c800a9aeb349bff2132d175"}
-mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "3f5f90d190f537857c800a9aeb349bff2132d175"}
+commitment_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "56517b55920ea7afc811baa541c859dadc8ae50a"}
+mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "56517b55920ea7afc811baa541c859dadc8ae50a"}
 
 # This dependency is not used by the crate, but is a subdependency of commitment_dlog
 # This features must be enable to build with WASM support

--- a/base/src/account/mod.rs
+++ b/base/src/account/mod.rs
@@ -63,10 +63,9 @@ impl mina_hasher::Hashable for Account {
         let mut roi = ROInput::new();
         roi
             // .append_hashable(self.public_key)
-            // FIXME: avoid doing clone here once https://github.com/o1-labs/proof-systems/pull/486 is merged
-            .append_hashable(self.token_id.clone())
+            .append_hashable(&self.token_id)
             // .append_hashable(self.token_permissions)
-            .append_hashable(self.balance)
+            .append_hashable(&self.balance)
             // .append_hashable(self.nonce)
             // .append_hashable(self.receipt_chain_hash)
             // .append_hashable(self.delegate)

--- a/base/src/account/mod.rs
+++ b/base/src/account/mod.rs
@@ -8,6 +8,8 @@ pub mod permissions;
 pub mod timing;
 pub mod token_permissions;
 
+use proof_systems::*;
+
 use mina_hasher::ROInput;
 pub use permissions::{AuthRequired, Permissions};
 pub use timing::Timing;

--- a/base/src/account/mod.rs
+++ b/base/src/account/mod.rs
@@ -8,6 +8,7 @@ pub mod permissions;
 pub mod timing;
 pub mod token_permissions;
 
+use mina_hasher::ROInput;
 pub use permissions::{AuthRequired, Permissions};
 pub use timing::Timing;
 pub use token_permissions::TokenPermissions;
@@ -51,4 +52,33 @@ pub struct Account {
     pub permissions: Permissions,
     /// TODO: This should contain a Snapp account data once we have something to test against
     pub snapp: Option<()>,
+}
+
+impl mina_hasher::Hashable for Account {
+    type D = ();
+
+    // Uncomment these fields once they have implemented Hashable trait
+    // and add unit tests when it's complete
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi
+            // .append_hashable(self.public_key)
+            // FIXME: avoid doing clone here once https://github.com/o1-labs/proof-systems/pull/486 is merged
+            .append_hashable(self.token_id.clone())
+            // .append_hashable(self.token_permissions)
+            .append_hashable(self.balance)
+            // .append_hashable(self.nonce)
+            // .append_hashable(self.receipt_chain_hash)
+            // .append_hashable(self.delegate)
+            // .append_hashable(self.voting_for)
+            // .append_hashable(self.timing)
+            // .append_hashable(self.permissions)
+            // .append_hashable(self.snapp)
+            ;
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        Some("CodaAccount".into())
+    }
 }

--- a/base/src/numbers.rs
+++ b/base/src/numbers.rs
@@ -5,6 +5,8 @@
 
 use std::fmt;
 
+use proof_systems::*;
+
 use derive_deref::Deref;
 use derive_more::From;
 use mina_crypto::{hex::skip_0x_prefix_when_needed, prelude::*};

--- a/base/src/numbers.rs
+++ b/base/src/numbers.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use derive_deref::Deref;
 use derive_more::From;
 use mina_crypto::{hex::skip_0x_prefix_when_needed, prelude::*};
+use mina_hasher::ROInput;
 use num::Integer;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -20,11 +21,24 @@ use crate::constants::MINA_PRECISION;
 /// Newtype for TokenIds
 pub struct TokenId(pub u64);
 
+impl mina_hasher::Hashable for TokenId {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_u64(self.0);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
+}
+
 #[derive(
     Clone, Serialize, Deserialize, PartialEq, PartialOrd, Debug, Hash, Copy, Default, Deref, From,
 )]
 #[from(forward)]
-
 /// Represents the length of something (e.g. an epoch or window)
 pub struct Length(pub u32);
 
@@ -73,6 +87,20 @@ impl fmt::Display for Amount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (q, r) = self.0.div_rem(&MINA_PRECISION);
         write!(f, "{}.{:#09}", q, r)
+    }
+}
+
+impl mina_hasher::Hashable for Amount {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_u64(self.0);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
     }
 }
 
@@ -211,41 +239,5 @@ impl From<BigInt256> for ark_ff::BigInteger256 {
     fn from(i: BigInt256) -> Self {
         use ark_ff::bytes::FromBytes;
         Self::read(&i.0[..]).unwrap()
-    }
-}
-
-#[cfg(test)]
-pub mod tests {
-    use crate::numbers::*;
-    use crate::types::ParseAmountError;
-    use std::str::FromStr;
-
-    #[test]
-    pub fn test_amount_to_string() {
-        assert_eq!(Amount(0).to_string(), "0.000000000");
-        assert_eq!(Amount(3).to_string(), "0.000000003");
-        assert_eq!(Amount(1000000003).to_string(), "1.000000003");
-        assert_eq!(Amount(1000000030).to_string(), "1.000000030");
-        assert_eq!(Amount(1300000000).to_string(), "1.300000000");
-        assert_eq!(Amount(1000000000).to_string(), "1.000000000");
-    }
-
-    #[test]
-    pub fn test_amount_from_string() {
-        assert_eq!(Amount::from_str("0.000000000").unwrap(), Amount(0));
-        assert_eq!(Amount::from_str("0.000000003").unwrap(), Amount(3));
-        assert_eq!(Amount::from_str("1.000000003").unwrap(), Amount(1000000003));
-        assert_eq!(Amount::from_str("1.000000030").unwrap(), Amount(1000000030));
-        assert_eq!(Amount::from_str("1.300000000").unwrap(), Amount(1300000000));
-        assert_eq!(Amount::from_str("1.000000000").unwrap(), Amount(1000000000));
-
-        assert_eq!(
-            Amount::from_str("0.000000000.0").unwrap_err(),
-            ParseAmountError::ErrorInvalidFormat("0.000000000.0".to_string())
-        );
-        assert_eq!(
-            Amount::from_str("000000000").unwrap_err(),
-            ParseAmountError::ErrorInvalidFormat("000000000".to_string())
-        );
     }
 }

--- a/base/src/protocol_state_proof/opening_proof.rs
+++ b/base/src/protocol_state_proof/opening_proof.rs
@@ -4,9 +4,6 @@
 use crate::types::{FieldElement, FiniteECPoint, FiniteECPointPairVec};
 use serde::{Deserialize, Serialize};
 
-use ark_ec::models::ModelParameters;
-use ark_ec::short_weierstrass_jacobian::GroupAffine;
-
 #[derive(Clone, Serialize, Deserialize, Default, PartialEq, Debug)]
 pub struct OpeningProof {
     pub lr: FiniteECPointPairVec,
@@ -14,21 +11,4 @@ pub struct OpeningProof {
     pub z_2: FieldElement,
     pub delta: FiniteECPoint,
     pub sg: FiniteECPoint,
-}
-
-impl<P> From<OpeningProof> for commitment_dlog::commitment::OpeningProof<GroupAffine<P>>
-where
-    P: ark_ec::SWModelParameters,
-    <P as ModelParameters>::BaseField: From<ark_ff::BigInteger256>,
-    <P as ModelParameters>::ScalarField: From<ark_ff::BigInteger256>,
-{
-    fn from(t: OpeningProof) -> Self {
-        Self {
-            lr: t.lr.into(),
-            delta: t.delta.into(),
-            z1: ark_ff::BigInteger256::from(t.z_1).into(),
-            z2: ark_ff::BigInteger256::from(t.z_2).into(),
-            sg: t.sg.into(),
-        }
-    }
 }

--- a/base/src/protocol_state_proof/proof_evaluations.rs
+++ b/base/src/protocol_state_proof/proof_evaluations.rs
@@ -15,21 +15,3 @@ pub struct ProofEvaluations {
     pub sigma1: FieldElementVec,
     pub sigma2: FieldElementVec,
 }
-
-impl<Fs> From<ProofEvaluations> for plonk_circuits::scalars::ProofEvaluations<Vec<Fs>>
-where
-    Fs: From<ark_ff::BigInteger256>,
-{
-    fn from(t: ProofEvaluations) -> Self {
-        Self {
-            l: t.l.into(),
-            r: t.r.into(),
-            o: t.o.into(),
-            z: t.z.into(),
-            t: t.t.into(),
-            f: t.f.into(),
-            sigma1: t.sigma1.into(),
-            sigma2: t.sigma2.into(),
-        }
-    }
-}

--- a/base/src/protocol_state_proof/proof_messages.rs
+++ b/base/src/protocol_state_proof/proof_messages.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use ark_ec::models::short_weierstrass_jacobian::GroupAffine;
 use ark_ec::models::ModelParameters;
 
+use proof_systems::*;
+
 #[derive(Clone, Serialize, Deserialize, Default, PartialEq, Debug)]
 pub struct ProofMessages {
     pub l_comm: ProofMessageWithoutDegreeBoundList,

--- a/base/src/protocol_state_proof/proof_messages.rs
+++ b/base/src/protocol_state_proof/proof_messages.rs
@@ -16,22 +16,6 @@ pub struct ProofMessages {
     pub t_comm: ProofMessageWithDegreeBound,
 }
 
-impl<P> From<ProofMessages> for plonk_protocol_dlog::prover::ProverCommitments<GroupAffine<P>>
-where
-    P: ark_ec::SWModelParameters,
-    <P as ModelParameters>::BaseField: From<ark_ff::BigInteger256>,
-{
-    fn from(t: ProofMessages) -> Self {
-        Self {
-            l_comm: t.l_comm.into(),
-            r_comm: t.r_comm.into(),
-            o_comm: t.o_comm.into(),
-            z_comm: t.z_comm.into(),
-            t_comm: t.t_comm.into(),
-        }
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize, Default, PartialEq, Debug)]
 pub struct ProofMessageWithoutDegreeBoundList(pub Vec<FiniteECPoint>);
 

--- a/base/tests/numbers.rs
+++ b/base/tests/numbers.rs
@@ -3,13 +3,14 @@
 
 #[cfg(test)]
 pub mod tests {
-    use std::str::FromStr;
+    use proof_systems::*;
 
     use super::*;
     use ark_ff::BigInteger256;
     use mina_hasher::*;
     use mina_rs_base::numbers::*;
     use num::BigUint;
+    use std::str::FromStr;
 
     #[test]
     pub fn test_amount_to_string() {

--- a/base/tests/numbers.rs
+++ b/base/tests/numbers.rs
@@ -3,10 +3,16 @@
 
 #[cfg(test)]
 pub mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use ark_ff::BigInteger256;
+    use mina_hasher::*;
     use mina_rs_base::numbers::*;
+    use num::BigUint;
 
     #[test]
-    pub fn test_amount_to_formatted_string() {
+    pub fn test_amount_to_string() {
         assert_eq!(Amount(0).to_string(), "0.000000000");
         assert_eq!(Amount(3).to_string(), "0.000000003");
         assert_eq!(Amount(1000000003).to_string(), "1.000000003");
@@ -16,10 +22,109 @@ pub mod tests {
     }
 
     #[test]
+    pub fn test_amount_from_string() {
+        assert_eq!(Amount::from_str("0.000000000").unwrap(), Amount(0));
+        assert_eq!(Amount::from_str("0.000000003").unwrap(), Amount(3));
+        assert_eq!(Amount::from_str("1.000000003").unwrap(), Amount(1000000003));
+        assert_eq!(Amount::from_str("1.000000030").unwrap(), Amount(1000000030));
+        assert_eq!(Amount::from_str("1.300000000").unwrap(), Amount(1300000000));
+        assert_eq!(Amount::from_str("1.000000000").unwrap(), Amount(1000000000));
+
+        assert_eq!(
+            Amount::from_str("0.000000000.0").unwrap_err(),
+            ParseAmountError::ErrorInvalidFormat("0.000000000.0".to_string())
+        );
+        assert_eq!(
+            Amount::from_str("000000000").unwrap_err(),
+            ParseAmountError::ErrorInvalidFormat("000000000".to_string())
+        );
+    }
+
+    #[test]
     fn test_convert_bigint_to_arkworks_zero() {
         use ark_ff::BigInteger256;
         let i = BigInt256([0; 32]);
         let ark_i: BigInteger256 = i.into();
         assert_eq!(ark_i, BigInteger256::default())
+    }
+
+    // Test cases are generated from OCaml code.
+    // Add below lines to `src/lib/mina_base/token_id.ml`
+    // then run `dune test` under `src/lib/mina_base/`
+    //
+    /*
+    let%test_unit "test_token_id_to_random_oracle_input" =
+      let print_hash n =
+        let fields =
+          n |> Unsigned.UInt64.of_int |> of_uint64 |> to_input
+          |> Random_oracle.pack_input
+        in
+        for i = 0 to Array.length fields - 1 do
+          Printf.printf "\"%s\",\n" (fields.(i) |> Snark_params.Tick.Field.to_string)
+        done ;
+        Printf.printf "\"%s\",\n"
+          ( fields |> Random_oracle.hash |> State_hash.of_hash
+          |> Snark_params.Tick.Field.to_string )
+      in
+      print_hash 0 ; print_hash 10 ; print_hash 6666
+            */
+    #[test]
+    fn parity_test_token_id_to_roinput() {
+        test_number_to_roinput!(
+            TokenId(0),
+            "10810255668636942098026103766265049994195917059170783454356350086236922262043"
+        );
+        test_number_to_roinput!(
+            TokenId(10),
+            "17356572411680406737150672960050062949049412030079764528419230045894285941469"
+        );
+        test_number_to_roinput!(
+            TokenId(6666),
+            "5166131045352968095909356988540174848079609264277513654820151010925011625414"
+        );
+    }
+
+    /*
+    let%test_unit "test_balance_to_random_oracle_input" =
+      let print_hash n =
+        let fields =
+          n |> Currency.Balance.of_int |> Currency.Balance.to_input
+          |> Random_oracle.pack_input
+        in
+        for i = 0 to Array.length fields - 1 do
+          Printf.printf "\"%s\",\n" (fields.(i) |> Snark_params.Tick.Field.to_string)
+        done ;
+        Printf.printf "\"%s\",\n"
+          ( fields |> Random_oracle.hash |> State_hash.of_hash
+          |> Snark_params.Tick.Field.to_string )
+      in
+      print_hash 0 ; print_hash 10 ; print_hash 6666
+
+         */
+    #[test]
+    fn parity_test_amount_to_roinput() {
+        test_number_to_roinput!(
+            Amount(0),
+            "10810255668636942098026103766265049994195917059170783454356350086236922262043"
+        );
+        test_number_to_roinput!(
+            Amount(10),
+            "17356572411680406737150672960050062949049412030079764528419230045894285941469"
+        );
+        test_number_to_roinput!(
+            Amount(6666),
+            "5166131045352968095909356988540174848079609264277513654820151010925011625414"
+        );
+    }
+
+    #[macro_export]
+    macro_rules! test_number_to_roinput {
+        ($num:expr, $expected_hash_str:expr) => {
+            let mut hasher = create_legacy(());
+            let hash = hasher.hash(&$num);
+            let big256: BigInteger256 = hash.into();
+            let big: BigUint = big256.into();
+            assert_eq!($expected_hash_str, big.to_str_radix(10))
+        };
     }
 }

--- a/proof-systems-shim/Cargo.toml
+++ b/proof-systems-shim/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["ChainSafe Systems <info@chainsafe.io>"]
+name = "proof-systems"
+version = "0.1.0"
+
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+commitment_dlog = {git = "https://github.com/o1-labs/proof-systems", rev = "56517b55920ea7afc811baa541c859dadc8ae50a"}
+mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "56517b55920ea7afc811baa541c859dadc8ae50a"}

--- a/proof-systems-shim/src/lib.rs
+++ b/proof-systems-shim/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0
+
+//! This is a shim crate that directly reexports crates under proof-systems.
+//! The idea is to manage those crates altogether,
+//! to make it easier to coordiate rev/version updates.
+//!
+//! Other crates in this repo should always depend on this shim crate instead of directly
+//! depending on crates from proof systems
+//!
+//! ```
+//! use proof_systems::*;
+//! use mina_hasher::Hashable;
+//! ```
+//!
+
+pub use commitment_dlog;
+pub use mina_hasher;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Implement `mina_hasher::Hashable` for the number fields of `Account`
- Parity tests with OCaml
- Remove some stale usage of proof-system libs that do not compile with the latest version
- Adds a shim crate to manage crates from proof-systems altogether to make sure crate versions do not collide with each other

This supersedes https://github.com/ChainSafe/mina-rs/pull/162

Upstream PR(s):
https://github.com/o1-labs/proof-systems/pull/486

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->