### PR TITLE
Implemented Hashable trait for ProtocolState

### DIFF
--- a/base/src/blockchain_state.rs
+++ b/base/src/blockchain_state.rs
@@ -5,6 +5,7 @@
 
 use crate::numbers::{BlockTime, TokenId};
 use mina_crypto::hash::*;
+use proof_systems::mina_hasher::{Hashable, ROInput};
 
 #[derive(Clone, Default, Debug, PartialEq)]
 /// Mina blockchain state struct
@@ -19,4 +20,22 @@ pub struct BlockchainState {
     pub snarked_next_available_token: TokenId,
     /// Timestamps for blocks
     pub timestamp: BlockTime,
+}
+
+impl Hashable for BlockchainState {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_hashable(&self.staged_ledger_hash);
+        roi.append_hashable(&self.snarked_ledger_hash);
+        roi.append_hashable(&self.genesis_ledger_hash);
+        roi.append_hashable(&self.snarked_next_available_token);
+        roi.append_hashable(&self.timestamp);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
 }

--- a/base/src/epoch_data.rs
+++ b/base/src/epoch_data.rs
@@ -5,6 +5,7 @@
 
 use crate::numbers::{Amount, Length};
 use mina_crypto::hash::*;
+use proof_systems::mina_hasher::{Hashable, ROInput};
 
 #[derive(Clone, Default, PartialEq, Debug)]
 /// Epoch Ledger
@@ -13,6 +14,21 @@ pub struct EpochLedger {
     pub hash: LedgerHash,
     /// The total currency in circulation after the block was produced. New issuance is via the coinbase reward and new account fees can reduce the total issuance.
     pub total_currency: Amount,
+}
+
+impl Hashable for EpochLedger {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_hashable(&self.hash);
+        roi.append_hashable(&self.total_currency);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
 }
 
 #[derive(Clone, Default, PartialEq, Debug)]
@@ -28,4 +44,22 @@ pub struct EpochData {
     pub lock_checkpoint: StateHash,
     /// Length of an epoch
     pub epoch_length: Length,
+}
+
+impl Hashable for EpochData {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_hashable(&self.ledger);
+        roi.append_hashable(&self.seed);
+        roi.append_hashable(&self.start_checkpoint);
+        roi.append_hashable(&self.lock_checkpoint);
+        roi.append_hashable(&self.epoch_length);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
 }

--- a/base/src/global_slot.rs
+++ b/base/src/global_slot.rs
@@ -4,6 +4,7 @@
 //! Structure of a global slot
 
 use crate::numbers::{self, Length};
+use proof_systems::mina_hasher::{Hashable, ROInput};
 
 #[derive(Clone, Default, PartialEq, Debug)]
 /// A global slot
@@ -12,4 +13,19 @@ pub struct GlobalSlot {
     pub slot_number: numbers::GlobalSlotNumber,
     /// Number of slots per epoch
     pub slots_per_epoch: Length,
+}
+
+impl Hashable for GlobalSlot {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_hashable(&self.slot_number);
+        roi.append_hashable(&self.slots_per_epoch);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
 }

--- a/base/src/numbers.rs
+++ b/base/src/numbers.rs
@@ -5,14 +5,11 @@
 
 use std::fmt;
 
-use proof_systems::*;
-
 use derive_deref::Deref;
 use derive_more::From;
 use mina_crypto::{hex::skip_0x_prefix_when_needed, prelude::*};
-use mina_hasher::ROInput;
 use num::Integer;
-
+use proof_systems::mina_hasher::{Hashable, ROInput};
 use thiserror::Error;
 use time::Duration;
 
@@ -23,7 +20,7 @@ use crate::constants::MINA_PRECISION;
 /// Newtype for TokenIds
 pub struct TokenId(pub u64);
 
-impl mina_hasher::Hashable for TokenId {
+impl Hashable for TokenId {
     type D = ();
 
     fn to_roinput(&self) -> ROInput {
@@ -41,6 +38,20 @@ impl mina_hasher::Hashable for TokenId {
 #[from(forward)]
 /// Represents the length of something (e.g. an epoch or window)
 pub struct Length(pub u32);
+
+impl Hashable for Length {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_u32(self.0);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
+}
 
 #[derive(Clone, PartialEq, PartialOrd, Debug, Hash, Copy, Default, From)]
 #[from(forward)]
@@ -84,7 +95,7 @@ impl fmt::Display for Amount {
     }
 }
 
-impl mina_hasher::Hashable for Amount {
+impl Hashable for Amount {
     type D = ();
 
     fn to_roinput(&self) -> ROInput {
@@ -137,7 +148,7 @@ impl std::str::FromStr for Amount {
 pub struct AccountNonce(pub u32);
 
 /// Consensus slot index
-#[derive(Copy, Clone, PartialEq, Debug, Hash, Default, From)]
+#[derive(Copy, Clone, PartialEq, Debug, Hash, Default, From, Deref)]
 #[from(forward)]
 pub struct GlobalSlotNumber(pub u32);
 
@@ -159,9 +170,37 @@ pub struct Hex64(pub i64);
 /// A single char defined by a single byte (not variable length like a Rust char)
 pub struct Char(pub u8);
 
+impl Hashable for GlobalSlotNumber {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_u32(self.0);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
+}
+
 #[derive(Clone, PartialEq, Debug, Hash, Default, From)]
 /// Block time numeric type
 pub struct BlockTime(pub u64);
+
+impl Hashable for BlockTime {
+    type D = ();
+
+    fn to_roinput(&self) -> ROInput {
+        let mut roi = ROInput::new();
+        roi.append_u64(self.0);
+        roi
+    }
+
+    fn domain_string(_: Self::D) -> Option<String> {
+        None
+    }
+}
 
 impl BlockTime {
     /// Unix timestamp conversion (seconds since the unix epoch)

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -20,6 +20,9 @@ bs58 = {version = "0.4", features = ["check"]}
 hex = "0.4"
 lazy_static = "1"
 thiserror = "1"
+lockfree-object-pool = "0.1"
+once_cell = "1"
+
 
 proof-systems = { path = "../proof-systems-shim" }
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 bin-prot = {path = "../protocol/bin-prot"}
 mina-serialization-types = {path = "../protocol/serialization-types"}
+proof-systems = {path = "../proof-systems-shim"}
 versioned = {path = "../protocol/versioned"}
 
 base64 = "0.13"


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- [Implemented hashable trait for ProtocolState and Used Kimchi Hasher](https://github.com/ChainSafe/mina-rs/pull/211/commits/0d6b5aa7e963c994e0601dad4540a06ac6fb226a)
- [Added select longer chain tie breaker logic test which use state hash comparison](https://github.com/ChainSafe/mina-rs/pull/211/commits/0d6b5aa7e963c994e0601dad4540a06ac6fb226a)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #166 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->