### PR TITLE
M1 - Add TypeAnnotation trait to support multiple serde formats (binprot and json)

### DIFF
--- a/apps/profilers/src/bin/block-serde-profiler.rs
+++ b/apps/profilers/src/bin/block-serde-profiler.rs
@@ -31,7 +31,7 @@ fn main() -> anyhow::Result<()> {
 
 fn cpu_profile_serialization() -> anyhow::Result<ExternalTransition> {
     let mut de = bin_prot::Deserializer::from_reader(BLOCK_BYTES);
-    let et: <ExternalTransition as SerializationTypeAnnotation>::BinProtType =
+    let et: <ExternalTransition as BinProtSerializationType>::T =
         serde::Deserialize::deserialize(&mut de)?;
     Ok(et.into())
 }

--- a/apps/profilers/src/bin/block-serde-profiler.rs
+++ b/apps/profilers/src/bin/block-serde-profiler.rs
@@ -1,9 +1,8 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-use bin_prot::encodable::BinProtEncodable;
 use clap::{Arg, Command};
-use mina_rs_base::types::ExternalTransition;
+use mina_rs_base::{types::*, *};
 use std::str::FromStr;
 
 const BLOCK_BYTES: &[u8] = include_bytes!("../../../../protocol/test-fixtures/src/data/block1");
@@ -31,7 +30,10 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn cpu_profile_serialization() -> anyhow::Result<ExternalTransition> {
-    Ok(ExternalTransition::try_decode_binprot(BLOCK_BYTES)?)
+    let mut de = bin_prot::Deserializer::from_reader(BLOCK_BYTES);
+    let et: <ExternalTransition as SerializationTypeAnnotation>::BinProtType =
+        serde::Deserialize::deserialize(&mut de)?;
+    Ok(et.into())
 }
 
 fn heap_profile_serialization() -> anyhow::Result<ExternalTransition> {

--- a/base/src/account/mod.rs
+++ b/base/src/account/mod.rs
@@ -10,17 +10,15 @@ pub mod token_permissions;
 
 use proof_systems::*;
 
-use mina_hasher::ROInput;
+use crate::{types::*, *};
+
 pub use permissions::{AuthRequired, Permissions};
 pub use timing::Timing;
 pub use token_permissions::TokenPermissions;
 
-use crate::numbers::{AccountNonce, Amount, TokenId};
 use mina_crypto::hash::{ChainHash, StateHash};
-
-use serde::{Deserialize, Serialize};
-
-use mina_serialization_types::v1::AccountV1;
+use mina_hasher::ROInput;
+use mina_serialization_types::v1::*;
 use proof_systems::mina_signer::CompressedPubKey;
 
 /// An account identified by its public key and token ID. Multiple accounts may
@@ -28,9 +26,7 @@ use proof_systems::mina_signer::CompressedPubKey;
 ///
 /// Accounts can also be Snapps in which case snapp data is required and proofs must
 /// be provided to perform certain actions
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(from = "AccountV1")]
-#[serde(into = "AccountV1")]
+#[derive(Clone, Debug)]
 pub struct Account {
     /// Account public key
     pub public_key: CompressedPubKey,
@@ -55,6 +51,12 @@ pub struct Account {
     pub permissions: Permissions,
     /// TODO: This should contain a Snapp account data once we have something to test against
     pub snapp: Option<()>,
+}
+
+impl SerializationTypeAnnotation for Account {
+    type BinProtType = AccountV1;
+    // TODO: Use actual AccountV1Json when it's implemented
+    type JsonType = AccountV1;
 }
 
 impl mina_hasher::Hashable for Account {

--- a/base/src/account/mod.rs
+++ b/base/src/account/mod.rs
@@ -53,10 +53,8 @@ pub struct Account {
     pub snapp: Option<()>,
 }
 
-impl SerializationTypeAnnotation for Account {
-    type BinProtType = AccountV1;
-    // TODO: Use actual AccountV1Json when it's implemented
-    type JsonType = Self;
+impl BinProtSerializationType for Account {
+    type T = AccountV1;
 }
 
 impl mina_hasher::Hashable for Account {

--- a/base/src/account/mod.rs
+++ b/base/src/account/mod.rs
@@ -56,7 +56,7 @@ pub struct Account {
 impl SerializationTypeAnnotation for Account {
     type BinProtType = AccountV1;
     // TODO: Use actual AccountV1Json when it's implemented
-    type JsonType = AccountV1;
+    type JsonType = Self;
 }
 
 impl mina_hasher::Hashable for Account {

--- a/base/src/external_transition.rs
+++ b/base/src/external_transition.rs
@@ -28,5 +28,5 @@ pub struct ExternalTransition {
 impl SerializationTypeAnnotation for ExternalTransition {
     type BinProtType = ExternalTransitionV1;
     // TODO: Use actual ExternalTransitionV1Json when it's implemented
-    type JsonType = ExternalTransitionV1;
+    type JsonType = Self;
 }

--- a/base/src/external_transition.rs
+++ b/base/src/external_transition.rs
@@ -3,13 +3,12 @@
 
 //! Mina ExternalTransition
 
-use crate::types::*;
-use serde::{Deserialize, Serialize};
+use crate::{types::*, *};
+
+use mina_serialization_types::v1::ExternalTransitionV1;
 
 /// This structure represents a mina block
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(from = "mina_serialization_types::v1::ExternalTransitionV1")]
-#[serde(into = "mina_serialization_types::v1::ExternalTransitionV1")]
+#[derive(Clone, Debug, PartialEq)]
 /// This structure represents a mina block received from an external block producer
 pub struct ExternalTransition {
     /// The blockchain state, including consensus and the ledger
@@ -26,6 +25,8 @@ pub struct ExternalTransition {
     pub proposed_protocol_version_opt: Option<ProtocolVersion>,
 }
 
-impl bin_prot::encodable::BinProtEncodable for ExternalTransition {
-    const PREALLOCATE_BUFFER_BYTES: usize = 13 * 1024;
+impl SerializationTypeAnnotation for ExternalTransition {
+    type BinProtType = ExternalTransitionV1;
+    // TODO: Use actual ExternalTransitionV1Json when it's implemented
+    type JsonType = ExternalTransitionV1;
 }

--- a/base/src/external_transition.rs
+++ b/base/src/external_transition.rs
@@ -25,8 +25,6 @@ pub struct ExternalTransition {
     pub proposed_protocol_version_opt: Option<ProtocolVersion>,
 }
 
-impl SerializationTypeAnnotation for ExternalTransition {
-    type BinProtType = ExternalTransitionV1;
-    // TODO: Use actual ExternalTransitionV1Json when it's implemented
-    type JsonType = Self;
+impl BinProtSerializationType for ExternalTransition {
+    type T = ExternalTransitionV1;
 }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -27,8 +27,8 @@ pub mod staged_ledger_diff;
 pub mod user_commands;
 pub mod verification_key;
 
-/// Re-export TypeAnnotation
-pub use mina_serialization_types::TypeAnnotation as SerializationTypeAnnotation;
+/// Re-export serialization type annotations
+pub use mina_serialization_types::{BinProtSerializationType, JsonSerializationType};
 
 /// Re-export all the public types under this module for convenience
 pub mod types {

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -27,6 +27,9 @@ pub mod staged_ledger_diff;
 pub mod user_commands;
 pub mod verification_key;
 
+/// Re-export TypeAnnotation
+pub use mina_serialization_types::TypeAnnotation as SerializationTypeAnnotation;
+
 /// Re-export all the public types under this module for convenience
 pub mod types {
     pub use super::account::*;

--- a/ledger/src/rocksdb_genesis_ledger.rs
+++ b/ledger/src/rocksdb_genesis_ledger.rs
@@ -6,7 +6,7 @@
 
 use crate::genesis_ledger::GenesisLedger;
 use bin_prot::from_reader;
-use mina_rs_base::account::Account;
+use mina_rs_base::{account::Account, *};
 use rocksdb::DB;
 use thiserror::Error;
 
@@ -34,8 +34,8 @@ impl<'a, const DEPTH: usize> RocksDbGenesisLedger<'a, DEPTH> {
 }
 
 fn decode_account_from_kv((_k, v): (Box<[u8]>, Box<[u8]>)) -> Result<Account, Error> {
-    let account = from_reader(&v[..])?;
-    Ok(account)
+    let account: <Account as SerializationTypeAnnotation>::BinProtType = from_reader(&v[..])?;
+    Ok(account.into())
 }
 
 impl<'a, const DEPTH: usize> IntoIterator for &RocksDbGenesisLedger<'a, DEPTH> {

--- a/ledger/src/rocksdb_genesis_ledger.rs
+++ b/ledger/src/rocksdb_genesis_ledger.rs
@@ -34,7 +34,7 @@ impl<'a, const DEPTH: usize> RocksDbGenesisLedger<'a, DEPTH> {
 }
 
 fn decode_account_from_kv((_k, v): (Box<[u8]>, Box<[u8]>)) -> Result<Account, Error> {
-    let account: <Account as SerializationTypeAnnotation>::BinProtType = from_reader(&v[..])?;
+    let account: <Account as BinProtSerializationType>::T = from_reader(&v[..])?;
     Ok(account.into())
 }
 

--- a/protocol/serialization-types/src/lib.rs
+++ b/protocol/serialization-types/src/lib.rs
@@ -36,6 +36,9 @@ pub mod protocol_version;
 pub mod signatures;
 pub mod staged_ledger_diff;
 
+mod type_annotation;
+pub use type_annotation::TypeAnnotation;
+
 /// Version 1 serialization types for the Mina protocol
 pub mod v1 {
     pub use super::account::{

--- a/protocol/serialization-types/src/lib.rs
+++ b/protocol/serialization-types/src/lib.rs
@@ -36,8 +36,8 @@ pub mod protocol_version;
 pub mod signatures;
 pub mod staged_ledger_diff;
 
-mod type_annotation;
-pub use type_annotation::TypeAnnotation;
+mod type_annotations;
+pub use type_annotations::*;
 
 /// Version 1 serialization types for the Mina protocol
 pub mod v1 {

--- a/protocol/serialization-types/src/type_annotation.rs
+++ b/protocol/serialization-types/src/type_annotation.rs
@@ -1,12 +1,12 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-/// This trait annotates a given type its different serializable types,
+/// This trait annotates a given type its different serialization types,
 /// and provide utility functions to easily convert between them
 pub trait TypeAnnotation: Sized {
-    /// The corresponding serializable type for bin-prot format
+    /// The corresponding serialization type for bin-prot format
     type BinProtType: From<Self> + Into<Self>;
 
-    /// The corresponding serializable type for json format
+    /// The corresponding serialization type for json format
     type JsonType: From<Self> + Into<Self>;
 }

--- a/protocol/serialization-types/src/type_annotation.rs
+++ b/protocol/serialization-types/src/type_annotation.rs
@@ -1,0 +1,12 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0
+
+/// This trait annotates a given type its different serializable types,
+/// and provide utility functions to easily convert between them
+pub trait TypeAnnotation: Sized {
+    /// The corresponding serializable type for bin-prot format
+    type BinProtType: From<Self> + Into<Self>;
+
+    /// The corresponding serializable type for json format
+    type JsonType: From<Self> + Into<Self>;
+}

--- a/protocol/serialization-types/src/type_annotation.rs
+++ b/protocol/serialization-types/src/type_annotation.rs
@@ -5,8 +5,12 @@
 /// and provide utility functions to easily convert between them
 pub trait TypeAnnotation: Sized {
     /// The corresponding serialization type for bin-prot format
+    /// Self type can be used here to indicate no special convertion is needed
+    /// TODO: Add default value when the feature lands on stable rust
     type BinProtType: From<Self> + Into<Self>;
 
     /// The corresponding serialization type for json format
+    /// Self type can be used here to indicate no special convertion is needed
+    /// TODO: Add default value when the feature lands on stable rust
     type JsonType: From<Self> + Into<Self>;
 }

--- a/protocol/serialization-types/src/type_annotations.rs
+++ b/protocol/serialization-types/src/type_annotations.rs
@@ -1,16 +1,19 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
-/// This trait annotates a given type its different serialization types,
-/// and provide utility functions to easily convert between them
-pub trait TypeAnnotation: Sized {
+/// This trait annotates a given type its corresponding bin-prot serialization type,
+pub trait BinProtSerializationType: Sized {
     /// The corresponding serialization type for bin-prot format
     /// Self type can be used here to indicate no special convertion is needed
     /// TODO: Add default value when the feature lands on stable rust
-    type BinProtType: From<Self> + Into<Self>;
+    type T: From<Self> + Into<Self>;
+}
 
+/// This trait annotates a given type its corresponding json serialization type,
+/// and provide utility functions to easily convert between them
+pub trait JsonSerializationType: Sized {
     /// The corresponding serialization type for json format
     /// Self type can be used here to indicate no special convertion is needed
     /// TODO: Add default value when the feature lands on stable rust
-    type JsonType: From<Self> + Into<Self>;
+    type T: From<Self> + Into<Self>;
 }


### PR DESCRIPTION
**Summary of changes**

This is part of https://github.com/ChainSafe/mina-rs/pull/209 it contains the minimal changes that add `TypeAnnotation` trait, to make review easier and unblock other's work that rely on this trait.

Changes introduced in this pull request:
- Add `TypeAnnotation` trait



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/mina-rs/issues/213


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->