### PR TITLE
M1 - Macro for testing binprot sum type

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "ark-ec"
@@ -174,9 +174,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
@@ -324,17 +324,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
- "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -659,9 +668,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "lock_api"
@@ -717,7 +726,7 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=9816b804fe2e8336fbe20d2e3d977d766582c4f0#9816b804fe2e8336fbe20d2e3d977d766582c4f0"
+source = "git+https://github.com/o1-labs/proof-systems?rev=52b859e9b5d81e94c4bc0e03cc66d4128419e7d6#52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -726,7 +735,7 @@ dependencies = [
 [[package]]
 name = "mina-hasher"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=9816b804fe2e8336fbe20d2e3d977d766582c4f0#9816b804fe2e8336fbe20d2e3d977d766582c4f0"
+source = "git+https://github.com/o1-labs/proof-systems?rev=52b859e9b5d81e94c4bc0e03cc66d4128419e7d6#52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"
 dependencies = [
  "ark-ff",
  "bitvec",
@@ -765,7 +774,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bin-prot",
- "clap 3.1.8",
+ "clap 3.1.12",
  "dhat",
  "mina-rs-base",
  "serde",
@@ -784,7 +793,7 @@ dependencies = [
 [[package]]
 name = "mina-signer"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=9816b804fe2e8336fbe20d2e3d977d766582c4f0#9816b804fe2e8336fbe20d2e3d977d766582c4f0"
+source = "git+https://github.com/o1-labs/proof-systems?rev=52b859e9b5d81e94c4bc0e03cc66d4128419e7d6#52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -802,12 +811,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -908,7 +916,7 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=9816b804fe2e8336fbe20d2e3d977d766582c4f0#9816b804fe2e8336fbe20d2e3d977d766582c4f0"
+source = "git+https://github.com/o1-labs/proof-systems?rev=52b859e9b5d81e94c4bc0e03cc66d4128419e7d6#52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -925,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -947,7 +955,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "oracle"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=9816b804fe2e8336fbe20d2e3d977d766582c4f0#9816b804fe2e8336fbe20d2e3d977d766582c4f0"
+source = "git+https://github.com/o1-labs/proof-systems?rev=52b859e9b5d81e94c4bc0e03cc66d4128419e7d6#52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -965,9 +973,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1276,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946fa04a8ac43ff78a1f4b811990afb9ddbdf5890b46d6dda0ba1998230138b7"
+checksum = "b827f2113224f3f19a665136f006709194bdfdcb1fdc1e4b2b5cbac8e0cced54"
 dependencies = [
  "rustversion",
  "serde",

--- a/apps/wasm/Cargo.lock
+++ b/apps/wasm/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "arrayref"
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -1135,9 +1135,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "libp2p"

--- a/proof-systems-shim/Cargo.toml
+++ b/proof-systems-shim/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "9816b804fe2e8336fbe20d2e3d977d766582c4f0"}
-mina-signer = {git = "https://github.com/o1-labs/proof-systems", rev = "9816b804fe2e8336fbe20d2e3d977d766582c4f0"}
-o1-utils = {git = "https://github.com/o1-labs/proof-systems", rev = "9816b804fe2e8336fbe20d2e3d977d766582c4f0"}
+mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"}
+mina-signer = {git = "https://github.com/o1-labs/proof-systems", rev = "52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"}
+o1-utils = {git = "https://github.com/o1-labs/proof-systems", rev = "52b859e9b5d81e94c4bc0e03cc66d4128419e7d6"}

--- a/protocol/serialization-types/tests/test-serialization.rs
+++ b/protocol/serialization-types/tests/test-serialization.rs
@@ -439,9 +439,16 @@ fn test_staged_ledger_diff_diff_commands_status() {
 #[wasm_bindgen_test]
 fn test_staged_ledger_diff_diff_coinbase() {
     block_path_test_batch! {
-        Option<CoinBaseFeeTransferV1> => "t/staged_ledger_diff/t/diff/t/0/t/t/coinbase/t/[sum]"
         CoinBaseV1 => "t/staged_ledger_diff/t/diff/t/0/t/t/coinbase"
     }
+    block_sum_path_test!(
+        "t/staged_ledger_diff/t/diff/t/0/t/t/coinbase/t/[sum]",
+        Option<CoinBaseFeeTransferV1>,
+        // other variant (dummy)
+        // replace this with the actual types
+        // once CoinBase::Zero and CoinBase::Two are implemented,
+        CoinBaseFeeTransferV1,
+    );
 }
 
 #[test]
@@ -596,6 +603,21 @@ macro_rules! block_path_test {
     ($typ:ty, $path:expr) => {
         for block in TEST_BLOCKS.values() {
             test_in_block::<$typ>(&block.value, &[$path]);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! block_sum_path_test {
+    ($path:expr, $($typ:ty,)*) => {
+        for block in TEST_BLOCKS.values() {
+            let mut success = 0;
+            $(
+                if std::panic::catch_unwind(|| test_in_block::<$typ>(&block.value, &[$path])).is_ok() {
+                    success += 1;
+                }
+            )*
+            assert_eq!(success, 1);
         }
     };
 }


### PR DESCRIPTION
**Summary of changes**

Previously, we assume the enum variant of a sum type in tests, which is bad and unscalabe when more than one variant appear in the test blocks.   This PR adds a new macro for testing sum types by asserting exactly one variant get deserializaed into successfully.

Changes introduced in this pull request:
- 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->