### PR TITLE
Auto-publish rustdoc to gh-pages

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,6 @@ env:
   CARGO_INCREMENTAL: 1
   # Investigate why it does not build with this flag
   # RUSTFLAGS: -Ctarget-cpu=native
-  RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 
 jobs:
   checks:
@@ -261,6 +260,9 @@ jobs:
           chmod +x codecov
           ./codecov -f lcov.info -Z
   gh-pages:
+    env:
+      # https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#--index-page-provide-a-top-level-landing-page-for-docs
+      RUSTDOCFLAGS: "-Zunstable-options --enable-index-page --show-coverage"
     runs-on: ubuntu-latest
     steps:
       - run: lscpu
@@ -281,7 +283,7 @@ jobs:
           toolchain: nightly
           components:
           override: true
-      - run: cargo doc --all --no-deps
+      - run: cargo doc --workspace --no-deps --all-features
       - run: mkdir -p /tmp/gh-pages/
       - run: mv ./target/doc /tmp/gh-pages/rustdoc
       - uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,7 @@ env:
   CARGO_INCREMENTAL: 1
   # Investigate why it does not build with this flag
   # RUSTFLAGS: -Ctarget-cpu=native
+  RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 
 jobs:
   checks:
@@ -115,8 +116,6 @@ jobs:
           # fail-on-alert: true
       - run: cat ./.cache/benchmark-data.json
       - run: cargo bench --all-features --manifest-path apps/Cargo.toml
-      - run: cargo doc --no-deps --release --all-features
-      - run: cargo doc --no-deps --release --all-features --manifest-path apps/Cargo.toml
       - run: cargo clippy --release --all-features -- --deny warnings
       - run: cargo clippy --release --all-features --manifest-path apps/Cargo.toml -- --deny warnings
       - name: Run profilers
@@ -130,13 +129,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
-      - uses: actions/upload-artifact@v2
-        with:
-          name: doc
-          path: |
-            target/doc/**/*
-            apps/target/doc/**/*
-          if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
           name: criterion
@@ -177,9 +169,6 @@ jobs:
       - run: cargo clippy --release --all-features --target wasm32-unknown-unknown -- --deny warnings
       - run: cargo clippy --release --all-features --target wasm32-unknown-unknown --manifest-path apps/Cargo.toml -- --deny warnings
       - run: cargo clippy --release --all-features --target wasm32-unknown-unknown --manifest-path apps/wasm/Cargo.toml -- --deny warnings
-      - run: cargo doc --no-deps --release --all-features --target wasm32-unknown-unknown
-      - run: cargo doc --no-deps --release --all-features --target wasm32-unknown-unknown --manifest-path apps/Cargo.toml
-      - run: cargo doc --no-deps --release --all-features --target wasm32-unknown-unknown --manifest-path apps/wasm/Cargo.toml
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: wasm-pack tests for test-serialization
@@ -271,3 +260,32 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov -f lcov.info -Z
+  gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - run: lscpu
+      - uses: actions/checkout@v2
+      - run: cat .github/cargo-config > $HOME/.cargo/config
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-x86_64-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components:
+          override: true
+      - run: cargo doc --all --no-deps
+      - run: mkdir -p /tmp/gh-pages/
+      - run: mv ./target/doc /tmp/gh-pages/rustdoc
+      - uses: peaceiris/actions-gh-pages@v3
+        # if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/gh-pages

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -125,6 +125,11 @@ jobs:
           sudo apt-get install -y valgrind graphviz
           sudo pip install gprof2dot
           ./scripts/profiler.sh
+      - uses: peaceiris/actions-gh-pages@v3
+        # if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
       - uses: actions/upload-artifact@v2
         with:
           name: doc

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,11 +123,6 @@ jobs:
           sudo apt-get install -y valgrind graphviz
           sudo pip install gprof2dot
           ./scripts/profiler.sh
-      - uses: peaceiris/actions-gh-pages@v3
-        # if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
       - uses: actions/upload-artifact@v2
         with:
           name: criterion
@@ -262,7 +257,7 @@ jobs:
   gh-pages:
     env:
       # https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#--index-page-provide-a-top-level-landing-page-for-docs
-      RUSTDOCFLAGS: "-Zunstable-options --enable-index-page --show-coverage"
+      RUSTDOCFLAGS: "-Zunstable-options --enable-index-page"
     runs-on: ubuntu-latest
     steps:
       - run: lscpu
@@ -276,18 +271,19 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-x86_64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-gh-pages-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           components:
           override: true
-      - run: cargo doc --workspace --no-deps --all-features
-      - run: mkdir -p /tmp/gh-pages/
-      - run: mv ./target/doc /tmp/gh-pages/rustdoc
+      - run: cargo +nightly doc --workspace --all-features --no-deps
+      - run: mkdir -p ./gh-pages/
+      - run: mv ./target/doc ./gh-pages/rustdoc
+      - run: ls -al ./gh-pages/rustdoc
       - uses: peaceiris/actions-gh-pages@v3
-        # if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: /tmp/gh-pages
+          publish_dir: ./gh-pages

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An implementation of Mina protocol in Rust, with focus on web and Wasm compatibi
 
 ** As you can probably tell this is a WIP! Don't use for anything yet **
 
-Rust doc of `main` branch can be found [here](https://chainsafe.github.io/mina-rs/rustdoc/index.html)
+Rust doc of `main` branch can be found [here](https://chainsafe.github.io/mina-rs/rustdoc/)
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ An implementation of Mina protocol in Rust, with focus on web and Wasm compatibi
 
 ** As you can probably tell this is a WIP! Don't use for anything yet **
 
+Rust doc of `main` branch can be found [here](https://chainsafe.github.io/mina-rs/rustdoc/index.html)
+
 ## Building
 
 Mina builds with the latest stable version of Rust. See [installation instructions for your OS](https://www.rust-lang.org/tools/install).
@@ -41,6 +43,7 @@ cargo test -p test-serialization
 ```
 
 It is also possible to run the serialization tests in a Wasm environment using wasm-pack. First install wasm-pack with
+
 ```shell
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 ```
@@ -52,10 +55,13 @@ cd protocol/test-serialization
 ```
 
 and then run tests with either
+
 ```shell
 wasm-pack test --node --release
 ```
+
 or
+
 ```shell
 wasm-pack test --headless --chrome --release --features browser
 ```
@@ -65,11 +71,12 @@ wasm-pack test --headless --chrome --release --features browser
 ### Reporting a Security Bug
 
 We take all security issues seriously, if you believe you have found a security issue within a ChainSafe
-project please notify us immediately. If an issue is confirmed, we will take all necessary precautions 
+project please notify us immediately. If an issue is confirmed, we will take all necessary precautions
 to ensure a statement and patch release is made in a timely manner.
 
 Please email us a description of the flaw and any related information (e.g. reproduction steps, version) to
 [security at chainsafe dot io](mailto:security@chainsafe.io).
 
-## License 
+## License
+
 Mina-rs is licensed under [Apache 2.0](https://github.com/ChainSafe/mina-rs/blob/main/LICENSE).

--- a/consensus/src/common.rs
+++ b/consensus/src/common.rs
@@ -1,7 +1,9 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
+//!
 //! Implements common APIs for the blockchain in the context of consensus.
+//!
 
 use crate::error::ConsensusError;
 use hex::ToHex;
@@ -11,6 +13,7 @@ use mina_rs_base::global_slot::GlobalSlot;
 use mina_rs_base::protocol_state::{Header, ProtocolState};
 use mina_rs_base::types::{BlockTime, Length};
 
+/// Type that defines constant values for mina consensus calculation
 // TODO: derive from protocol constants
 pub struct ConsensusConstants {
     /// Point of finality (number of confirmations)
@@ -30,6 +33,7 @@ pub struct ConsensusConstants {
 }
 
 impl ConsensusConstants {
+    /// Pre-defined constant values for mainnet
     pub fn mainnet() -> Self {
         Self {
             k: Length(290),
@@ -42,19 +46,23 @@ impl ConsensusConstants {
         }
     }
 
+    /// Pre-defined constant values for devnet
     pub fn devnet() -> Self {
         todo!()
     }
 }
 
+/// A chain of [ProtocolState]
 #[derive(Debug, Default)]
 // TODO: replace vec element with ExternalTransition
 pub struct ProtocolStateChain(pub Vec<ProtocolState>);
 
+/// Trait that represents a chain of block data structure
 pub trait Chain<T>
 where
     T: Header,
 {
+    /// Pushes an item into the chain
     fn push(&mut self, new: T) -> Result<(), ConsensusError>;
     /// This function returns the last block of a given chain.
     /// The input is a chain C and the output is last block of C
@@ -77,6 +85,7 @@ where
     /// This function returns hash of the top block's protocol state for a given chain.
     /// The input is a chain C and the output is the hash.
     fn state_hash(&self) -> Option<StateHash>;
+    /// Gets [ProtocolState] of the genesis block
     fn genesis_block(&self) -> Option<&ProtocolState>;
 }
 
@@ -138,7 +147,9 @@ impl Chain<ProtocolState> for ProtocolStateChain {
     }
 }
 
+/// A trait that defines operations for consensus calculation
 pub trait Consensus {
+    /// Chain type
     type Chain;
     /// Top level API to select between chains during a fork.
     fn select_secure_chain<'a>(

--- a/consensus/src/error.rs
+++ b/consensus/src/error.rs
@@ -1,16 +1,30 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
+//!
+//! Types that represent errors in mina consensus operations
+//!
+
+/// Type that represents errors in mina consensus operations
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum ConsensusError {
+    /// header must have height 1 greater than top
     #[error("header must have height 1 greater than top")]
     InvalidHeight,
+
+    /// Top block not found
     #[error("Top block not found")]
     TopBlockNotFound,
+
+    /// Global slot not found
     #[error("Global slot not found")]
     GlobalSlotNotFound,
+
+    /// Consensus state not found
     #[error("Consensus state not found")]
     ConsensusStateNotFound,
+
+    /// candidates not found
     #[error("candidates not found")]
     CandidatesNotFound,
 }

--- a/consensus/src/genesis/config.rs
+++ b/consensus/src/genesis/config.rs
@@ -15,10 +15,13 @@ const ERR_FAIL_TO_DECODE_B64: &str = "Failed to decode hash from base64";
 const ERR_FAIL_TO_DECODE_HEX: &str = "Failed to decode hash from hex";
 
 lazy_static::lazy_static! {
+    /// Config instance for initializing genesis block in mainnet
     pub static ref MAINNET_CONFIG: GenesisInitConfig = GenesisInitConfig::mainnet();
+    /// Config instance for initializing genesis block in devnet
     pub static ref DEVNET_CONFIG: GenesisInitConfig = GenesisInitConfig::devnet();
 }
 
+/// Config for initializing genesis block
 pub struct GenesisInitConfig {
     pub(crate) constants: ProtocolConstants,
 

--- a/consensus/src/genesis/mod.rs
+++ b/consensus/src/genesis/mod.rs
@@ -1,10 +1,14 @@
 // Copyright 2020 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0
 
+//!
+//! This modules contains all genesis block related stuff
+//!
+
 mod config;
 pub use config::*;
 use mina_rs_base::types::*;
-pub mod genesis_impl;
+mod genesis_impl;
 
 /// Trait for genesis block initialization logic
 /// # Example
@@ -15,5 +19,6 @@ pub mod genesis_impl;
 /// let genesis_devnet = ExternalTransition::from_genesis_config(&DEVNET_CONFIG);
 /// ```
 pub trait Genesis {
+    /// Constructs a genesis block from config
     fn from_genesis_config(config: &GenesisInitConfig) -> ExternalTransition;
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(warnings)]
-#![deny(rustdoc::all)]
-#![allow(rustdoc::private_doc_tests)]
+#![deny(missing_docs)]
 
 //!
 //! Contains definitions of data structures and APIs for mina consensus


### PR DESCRIPTION
**Summary of changes**

Publish rustdoc on every commit to main branch, the doc is available at https://chainsafe.github.io/mina-rs/rustdoc/

Changes introduced in this pull request:
- Auto-publish rustdoc to gh-pages
- Add missing docs
- Add link of rustdoc generated from main branch to readme.md




**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/ChainSafe/mina-rs/issues/215


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->