### PR TITLE
M1 - Block serde e2e roundtrip tests

### DIFF
--- a/protocol/test-serialization/Cargo.toml
+++ b/protocol/test-serialization/Cargo.toml
@@ -18,9 +18,9 @@ bin-prot = {path = "../bin-prot"}
 mina-consensus = {path = "../../consensus"}
 mina-crypto = {path = "../../crypto"}
 mina-rs-base = {path = "../../base"}
-test-fixtures = {path = "../test-fixtures"}
 mina-serialization-types = {path = "../serialization-types"}
-
+proof-systems = {path = "../../proof-systems-shim"}
+test-fixtures = {path = "../test-fixtures"}
 
 anyhow = "1"
 base64 = "0.13"
@@ -31,8 +31,6 @@ rand = "0.8"
 serde = {version = "1", features = ["derive"]}
 time = {version = "0.3", features = ["macros"]}
 wasm-bindgen-test = "0.3"
-
-proof-systems = { path = "../../proof-systems-shim" }
 
 [profile.bench]
 lto = true

--- a/protocol/test-serialization/src/e2e.rs
+++ b/protocol/test-serialization/src/e2e.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use mina_rs_base::types::*;
+    use mina_serialization_types::*;
+    use pretty_assertions::assert_eq;
+    use test_fixtures::TEST_BLOCKS;
+    use wasm_bindgen_test::*;
+
+    #[test]
+    #[wasm_bindgen_test]
+    fn test_block_serde_roundtrip() {
+        for block in TEST_BLOCKS.values() {
+            let versioned = block.external_transitionv1().unwrap();
+
+            let et: ExternalTransition = versioned.clone().into();
+            let versioned2: <ExternalTransition as BinProtSerializationType>::T = et.into();
+            assert_eq!(versioned, versioned2);
+
+            let mut bytes = Vec::with_capacity(block.bytes.len());
+            bin_prot::to_writer(&mut bytes, &versioned).unwrap();
+            assert_eq!(bytes.as_slice(), block.bytes.as_slice(),);
+        }
+    }
+}

--- a/protocol/test-serialization/src/lib.rs
+++ b/protocol/test-serialization/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(all(test, feature = "browser"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
+mod e2e;
 mod fuzz;
 mod genesis;
 #[allow(non_snake_case)]


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Add Block serde e2e roundtrip tests to increase codecov of conversion code between block types and bin-prot serialization block types

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->