### PR TITLE
MVP - Employ block verification flow in NaiveTransitionFrontier

### DIFF
--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -1421,9 +1421,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/Cargo.lock
+++ b/apps/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -732,7 +732,7 @@ dependencies = [
 [[package]]
 name = "mina-hasher"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ff",
  "bitvec",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "mina-signer"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -983,7 +983,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "oracle"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/apps/wasm/Cargo.lock
+++ b/apps/wasm/Cargo.lock
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2071,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "mina-hasher"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ff",
  "bitvec",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "mina-signer"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2513,7 +2513,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "oracle"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=b883501b06375da79fc9965c1c17e02a72e9ded7#b883501b06375da79fc9965c1c17e02a72e9ded7"
+source = "git+https://github.com/o1-labs/proof-systems?rev=3bae9501e10c9c01eb965e7695ec715ad6672630#3bae9501e10c9c01eb965e7695ec715ad6672630"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3569,9 +3569,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
  "bytes",
  "libc",
@@ -3587,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/wasm/Cargo.lock
+++ b/apps/wasm/Cargo.lock
@@ -332,9 +332,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -2107,6 +2107,7 @@ dependencies = [
  "mina-rs-base",
  "mina-serialization-types",
  "multihash",
+ "proof-systems",
  "serde",
  "serde_json",
  "tokio",
@@ -3459,9 +3460,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/base/tests/verification.rs
+++ b/base/tests/verification.rs
@@ -6,15 +6,29 @@ mod tests {
     use mina_rs_base::types::ExternalTransition;
     use mina_rs_base::user_commands::SignedCommandPayload;
     use mina_rs_base::verifiable::Verifiable;
+    use mina_serialization_types::json::ExternalTransitionJson;
     use proof_systems::mina_signer::{self, NetworkId};
     use test_fixtures::*;
 
     #[test]
-    fn verify_all_fixtures() {
+    fn verify_all_binprot_fixtures() {
         let mut ctx = mina_signer::create_legacy::<SignedCommandPayload>(NetworkId::MAINNET);
 
         assert!(TEST_BLOCKS.iter().all(|(_, v)| {
             let block = ExternalTransition::from(v.external_transitionv1().unwrap());
+            block.verify(&mut ctx)
+        }))
+    }
+
+    #[test]
+    fn verify_all_json_fixtures() {
+        let mut ctx = mina_signer::create_legacy::<SignedCommandPayload>(NetworkId::MAINNET);
+
+        assert!(JSON_TEST_BLOCKS.iter().all(|(_, v)| {
+            let block: ExternalTransition =
+                serde_json::from_value::<ExternalTransitionJson>(v.clone())
+                    .unwrap()
+                    .into();
             block.verify(&mut ctx)
         }))
     }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,6 +15,7 @@ browser = []
 [dependencies]
 mina-consensus = {path = "../consensus"}
 mina-rs-base = {path = "../base"}
+proof-systems = {path = "../proof-systems-shim"}
 
 anyhow = "1"
 async-trait = "0.1"

--- a/proof-systems-shim/Cargo.toml
+++ b/proof-systems-shim/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "b883501b06375da79fc9965c1c17e02a72e9ded7"}
-mina-signer = {git = "https://github.com/o1-labs/proof-systems", rev = "b883501b06375da79fc9965c1c17e02a72e9ded7"}
-o1-utils = {git = "https://github.com/o1-labs/proof-systems", rev = "b883501b06375da79fc9965c1c17e02a72e9ded7"}
+mina-hasher = {git = "https://github.com/o1-labs/proof-systems", rev = "3bae9501e10c9c01eb965e7695ec715ad6672630"}
+mina-signer = {git = "https://github.com/o1-labs/proof-systems", rev = "3bae9501e10c9c01eb965e7695ec715ad6672630"}
+o1-utils = {git = "https://github.com/o1-labs/proof-systems", rev = "3bae9501e10c9c01eb965e7695ec715ad6672630"}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Verify blocks in the `NaiveTransitionFrontier` with the logic implemented in https://github.com/ChainSafe/mina-rs/pull/238
- Fix `Hashable` implementation for `StakeDelegation`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 


**Other information and links**
<!-- Add any other context about the pull request here. -->



<!-- Thank you 🔥 -->